### PR TITLE
Specify true and false as boolean

### DIFF
--- a/syntaxes/Ruby.json
+++ b/syntaxes/Ruby.json
@@ -129,11 +129,11 @@
     },
     {
       "match": "\\bnil\\b(?![?!])",
-      "name": "constant.nil.ruby"
+      "name": "constant.language.nil.ruby"
     },
     {
       "match": "\\b(true|false)\\b(?![?!])",
-      "name": "constant.boolean.ruby"
+      "name": "constant.language.boolean.ruby"
     },
     {
       "match": "\\b(__(FILE|LINE)__|self)\\b(?![?!])",


### PR DESCRIPTION
Moves true and false to `constant.boolean.ruby`. Maybe nil should have a more specific syntax group too?
