### PR TITLE
Add thor to ruby fileTypes

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -4,6 +4,7 @@
   'rjs'
   'Rakefile'
   'rake'
+  'thor'
   'cgi'
   'fcgi'
   'gemspec'


### PR DESCRIPTION
This patch simply adds thor files to the list of valid ruby fileTypes.
