### PR TITLE
Update match regex for nil?, nil!

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -106,7 +106,7 @@
     'name': 'keyword.control.pseudo-method.ruby'
   }
   {
-    'match': '\\bnil\\b(?![?!])'
+    'match': '\\bnil\\b[?!]?'
     'name': 'constant.language.nil.ruby'
   }
   {

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -1,0 +1,24 @@
+# Run specs on the Ruby language package
+#
+# While editiong this package in Atom, use the `Run Package Specs`
+# and observe the output.
+describe 'Ruby grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-ruby')
+
+    runs ->
+      grammar = atom.syntax.grammarForScopeName('source.ruby')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe 'source.ruby'
+
+  it 'tokenizes nil* variants in the correct scopes', ->
+    test = (word) ->
+      {tokens} = grammar.tokenizeLine(word)
+      expect(tokens[0]).toEqual value: word, scopes: ['source.ruby', 'constant.language.nil.ruby']
+    matchWords = ['nil', 'nil?', 'nil!']
+    test word for word in matchWords


### PR DESCRIPTION
Currently these are not behing syntax-highlighted due to incorrect
regular expression matching/capturing.

- Highlight `nil?`, `nil!` the same as `nil`.
  `nil!` is not a default Ruby method on NilClass, but is sometimes
  used when extending Objects to nil-ify them.

- Adds the first spec tests for Ruby grammar

I'm coming to Atom from TextMate2, where there's plenty of misbehaving going on already, so I'm happy to continue to work on extending Ruby to work correctly, just let me know before I sink too much :clock12: into learning more about CoffeeScript, Jasmine testing, Atom internals, etc. 

TextMate: 
![textmate_orig](https://f.cloud.github.com/assets/529516/2301920/5f079532-a164-11e3-986d-0d7351b3b54b.png)
Atom (unmodified):
![atom_orig](https://f.cloud.github.com/assets/529516/2301923/722f59ba-a164-11e3-94cd-cf5aecb698fe.png)
Atom (with fix)
![atom_patch13](https://f.cloud.github.com/assets/529516/2301926/96e7e650-a164-11e3-8dc2-5ec7aef4f52d.png)

