### PR TITLE
Fix the 'Insert do...end' snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -134,7 +134,7 @@
     'body': 'File.dirname(__FILE__)'
   'Insert do |variable| … end':
     'prefix': 'do'
-    'body': 'do |${1:variable}|\n\t$0\nend'
+    'body': 'do${1: |${2:variable}|}\n\t$0\nend'
   'each { |e| .. }':
     'prefix': 'ea'
     'body': 'each { |${1:e}| $0 }'


### PR DESCRIPTION
This commit adds an additional placeholder in the `do...end` snippet.
Currently, if you want to create a `do...end` without any argument, you end up with the following:

``` ruby
my_method do ||
end
```

which makes the snippet unusable (writing RSpec things for instance).
With this commit, the whole `|variable|` part is a placeholder. Then, when hitting `tab`, you move to the `variable` part and finally to the code part. It makes it more usable.
