### PR TITLE
Add snippets for erb tags

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -298,3 +298,10 @@
   ':yields:':
     'prefix': 'y'
     'body': ' :yields: ${0:arguments}'
+'.text.html.erb':
+  'erb_render_block':
+    'prefix': '='
+    'body': '<%= $1 %>'
+  'erb_exec_block':
+    'prefix': '-'
+    'body': '<% $1 %>'


### PR DESCRIPTION
Found this in [atom/language-ruby-on-rails](https://github.com/atom/language-ruby-on-rails) and I think Ruby ERB also need this.
