### PR TITLE
Added the always forgotton 'fail'  keyword

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -124,7 +124,7 @@
   }
   {
     'comment': ' everything being a method but having a special function is a..'
-    'match': '\\b(initialize|new|loop|include|extend|prepend|raise|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|module_function|public|protected)\\b(?![?!])'
+    'match': '\\b(initialize|new|loop|include|extend|prepend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|module_function|public|protected)\\b(?![?!])'
     'name': 'keyword.other.special-method.ruby'
   }
   {


### PR DESCRIPTION
I know `fail` is just synonyms with `raise`, but it's still part of the core keywords and it tends to be forgotten, but not anymore
