### PR TITLE
Add rabl to list of supported filetypes

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -16,6 +16,7 @@
   'rake'
   'Rakefile'
   'Rantfile'
+  'rabl'
   'rb'
   'rbx'
   'rjs'


### PR DESCRIPTION
This is a minor one but a super handy one to have, since `*.rabl` files are all 100% Ruby anyway.

![screenshot 2014-04-02 08 40 43](https://cloud.githubusercontent.com/assets/58783/2591538/7cad746e-ba6c-11e3-9822-b291f8e8fc9a.png)

Let me know if anything else needs to be added to this PR; I'm happy to oblige!
