### PR TITLE
Add more 'special' ruby methods

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -187,7 +187,7 @@
     'name': 'support.class.ruby'
   }
   {
-    'match': '\\b(abort|at_exit|autoload|autoload?|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|exit!|fork|format|gets|global_variables|gsub|iterator?|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])'
+    'match': '\\b(abort|at_exit|autoload\\??|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|exit!|fork|format|gets|global_variables|gsub|iterator\\?|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])'
     'name': 'support.function.kernel.ruby'
   }
   {


### PR DESCRIPTION
App puts, print, p, exec, eval and system to the list of 'special' ruby methods.

Should these (and other) kernel methods have their own matcher?
