### PR TITLE
Should handle interpolated ruby code properly

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1366,10 +1366,12 @@
   'interpolated_ruby':
     'patterns': [
       {
-        'begin': '#\\{'
+        'begin': '(#\\{)'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.ruby'
+          '1':
+            'name': 'source.ruby'
         'contentName': 'source.ruby'
         'end': '(\\})'
         'endCaptures':


### PR DESCRIPTION
This is how it looked before

![skarmavbild 2014-04-23 kl 23 32 25](https://cloud.githubusercontent.com/assets/220827/2783640/e707165c-cb2f-11e3-9796-5af708f28e5e.png)

This is how it looks after the patch is applied

![skarmavbild 2014-04-23 kl 23 37 28](https://cloud.githubusercontent.com/assets/220827/2783644/f04b1e84-cb2f-11e3-9de9-b165f5718e3b.png)

It now behaves in the same way Sublime does.
