### PR TITLE
Fix literal grammar

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -274,11 +274,15 @@
   }
   {
     'begin': ':\''
-    'captures':
+    'beginCaptures':
       '0':
-        'name': 'punctuation.definition.constant.ruby'
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': "symbol literal with '' delimitor"
     'end': '\''
-    'name': 'constant.other.symbol.single-quoted.ruby'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
     'patterns': [
       {
         'match': '\\\\[\'\\\\]'
@@ -288,11 +292,15 @@
   }
   {
     'begin': ':"'
-    'captures':
+    'beginCaptures':
       '0':
-        'name': 'punctuation.definition.constant.ruby'
+        'name': 'punctuation.section.symbol.begin.ruby'
+    'comment': 'symbol literal with "" delimitor'
     'end': '"'
-    'name': 'constant.other.symbol.double-quoted.ruby'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.symbol.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -312,7 +320,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'single quoted string (does not allow interpolation)'
+    'comment': "string literal with '' delimitor"
     'end': '\''
     'endCaptures':
       '0':
@@ -330,12 +338,12 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'double quoted string (allows for interpolation)'
+    'comment': 'string literal with interpolation and "" delimitor'
     'end': '"'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.double.ruby'
+    'name': 'string.quoted.double.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -511,13 +519,13 @@
       \\s*((/))(?![*+{}?])'
     'captures':
       '1':
-        'name': 'string.regexp.classic.ruby'
+        'name': 'string.regexp.interpolated.ruby'
       '2':
-        'name': 'punctuation.definition.string.ruby'
-    'comment': 'regular expressions (normal)
+        'name': 'punctuation.section.regexp.ruby'
+    'comment': 'regular expression literal with interpolation and // delimitor
       we only start a regexp if the character before it (excluding whitespace)
       is what we think is before a regexp'
-    'contentName': 'string.regexp.classic.ruby'
+    'contentName': 'string.regexp.interpolated.ruby'
     'end': '((/[eimnosux]*))'
     'patterns': [
       {
@@ -529,13 +537,13 @@
     'begin': '%r\\{'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'regular expressions (literal)'
+        'name': 'punctuation.section.regexp.begin.ruby'
+    'comment': 'regular expression literal with interpolation and {} delimitor'
     'end': '\\}[eimnosux]*'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.regexp.mod-r.ruby'
+        'name': 'punctuation.section.regexp.end.ruby'
+    'name': 'string.regexp.interpolated.ruby'
     'patterns': [
       {
         'include': '#regex_sub'
@@ -549,13 +557,13 @@
     'begin': '%r\\['
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'regular expressions (literal)'
+        'name': 'punctuation.section.regexp.begin.ruby'
+    'comment': 'regular expression literal with interpolation and [] delimitor'
     'end': '\\][eimnosux]*'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.regexp.mod-r.ruby'
+        'name': 'punctuation.section.regexp.end.ruby'
+    'name': 'string.regexp.interpolated.ruby'
     'patterns': [
       {
         'include': '#regex_sub'
@@ -569,13 +577,13 @@
     'begin': '%r\\('
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'regular expressions (literal)'
+        'name': 'punctuation.section.regexp.begin.ruby'
+    'comment': 'regular expression literal with interpolation and () delimitor'
     'end': '\\)[eimnosux]*'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.regexp.mod-r.ruby'
+        'name': 'punctuation.section.regexp.end.ruby'
+    'name': 'string.regexp.interpolated.ruby'
     'patterns': [
       {
         'include': '#regex_sub'
@@ -589,13 +597,13 @@
     'begin': '%r\\<'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'regular expressions (literal)'
+        'name': 'punctuation.section.regexp.begin.ruby'
+    'comment': 'regular expression literal with interpolation and <> delimitor'
     'end': '\\>[eimnosux]*'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.regexp.mod-r.ruby'
+        'name': 'punctuation.section.regexp.end.ruby'
+    'name': 'string.regexp.interpolated.ruby'
     'patterns': [
       {
         'include': '#regex_sub'
@@ -609,13 +617,13 @@
     'begin': '%r([^\\w])'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'regular expressions (literal)'
+        'name': 'punctuation.section.regexp.begin.ruby'
+    'comment': 'regular expression literal with interpolation and {} delimitor'
     'end': '\\1[eimnosux]*'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.regexp.mod-r.ruby'
+        'name': 'punctuation.section.regexp.end.ruby'
+    'name': 'string.regexp.interpolated.ruby'
     'patterns': [
       {
         'include': '#regex_sub'
@@ -623,39 +631,16 @@
     ]
   }
   {
-    'begin': '%[QWSIR]?\\('
+    'begin': '%I\\['
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation ()'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.upper.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_parens_i'
-      }
-    ]
-  }
-  {
-    'begin': '%[QWSIR]?\\['
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation []'
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with interpolation and [] delimitor'
     'end': '\\]'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.upper.ruby'
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -669,16 +654,39 @@
     ]
   }
   {
-    'begin': '%[QWSIR]?\\<'
+    'begin': '%I\\('
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation <>'
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with interpolation and () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_parens_i'
+      }
+    ]
+  }
+  {
+    'begin': '%I\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with interpolation and <> delimitor'
     'end': '\\>'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.upper.ruby'
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -692,16 +700,16 @@
     ]
   }
   {
-    'begin': '%[QWSIR]?\\{'
+    'begin': '%I\\{'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation -- {}'
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with interpolation and {} delimitor'
     'end': '\\}'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.double.ruby.mod'
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -715,16 +723,444 @@
     ]
   }
   {
-    'begin': '%[QWSIR]([^\\w])'
+    'begin': '%I([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with interpolation and wildcard delimitor'
+    'end': '\\1'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '%i\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with [] delimitor'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\]|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_brackets'
+      }
+    ]
+  }
+  {
+    'begin': '%i\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\)|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_parens'
+      }
+    ]
+  }
+  {
+    'begin': '%i\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with <> delimitor'
+    'end': '\\>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\>|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_ltgt'
+      }
+    ]
+  }
+  {
+    'begin': '%i\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with {} delimitor'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\}|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_curly'
+      }
+    ]
+  }
+  {
+    'begin': '%i([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of symbols literal with wildcard delimitor'
+    'end': '\\1'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'comment': 'Cant be named because its not neccesarily an escape.'
+        'match': '\\\\.'
+      }
+    ]
+  }
+  {
+    'begin': '%W\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with interpolation and [] delimitor'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_brackets_i'
+      }
+    ]
+  }
+  {
+    'begin': '%W\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with interpolation and () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_parens_i'
+      }
+    ]
+  }
+  {
+    'begin': '%W\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with interpolation and <> delimitor'
+    'end': '\\>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_ltgt_i'
+      }
+    ]
+  }
+  {
+    'begin': '%W\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with interpolation and {} delimitor'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_curly_i'
+      }
+    ]
+  }
+  {
+    'begin': '%W([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with interpolation and wildcard delimitor'
+    'end': '\\1'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  }
+  {
+    'begin': '%w\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with [] delimitor'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\]|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_brackets'
+      }
+    ]
+  }
+  {
+    'begin': '%w\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\)|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_parens'
+      }
+    ]
+  }
+  {
+    'begin': '%w\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with <> delimitor'
+    'end': '\\>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\>|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_ltgt'
+      }
+    ]
+  }
+  {
+    'begin': '%w\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with {} delimitor'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\}|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_curly'
+      }
+    ]
+  }
+  {
+    'begin': '%w([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.array.begin.ruby'
+    'comment': 'array of strings literal with wildcard delimitor'
+    'end': '\\1'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.array.end.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'comment': 'Cant be named because its not neccesarily an escape.'
+        'match': '\\\\.'
+      }
+    ]
+  }
+  {
+    'begin': '%Q\\('
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation -- wildcard'
+    'comment': 'string literal with interpolation and () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_parens_i'
+      }
+    ]
+  }
+  {
+    'begin': '%Q\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'string literal with interpolation and [] delimitor'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_brackets_i'
+      }
+    ]
+  }
+  {
+    'begin': '%Q\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'string literal with interpolation and <> delimitor'
+    'end': '\\>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_ltgt_i'
+      }
+    ]
+  }
+  {
+    'begin': '%Q\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'string literal with interpolation and {} delimitor'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_curly_i'
+      }
+    ]
+  }
+  {
+    'begin': '%Q([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'string literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.upper.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -739,12 +1175,12 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal capable of interpolation -- wildcard'
+    'comment': 'string literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.other.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
     'patterns': [
       {
         'include': '#interpolated_ruby'
@@ -755,16 +1191,16 @@
     ]
   }
   {
-    'begin': '%[qwsi]\\('
+    'begin': '%q\\('
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal incapable of interpolation -- ()'
+    'comment': 'string literal with () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.lower.ruby'
+    'name': 'string.quoted.other.ruby'
     'patterns': [
       {
         'match': '\\\\\\)|\\\\\\\\'
@@ -776,16 +1212,16 @@
     ]
   }
   {
-    'begin': '%[qwsi]\\<'
+    'begin': '%q\\<'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal incapable of interpolation -- <>'
+    'comment': 'string literal with <> delimitor'
     'end': '\\>'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.lower.ruby'
+    'name': 'string.quoted.other.ruby'
     'patterns': [
       {
         'match': '\\\\\\>|\\\\\\\\'
@@ -797,16 +1233,16 @@
     ]
   }
   {
-    'begin': '%[qwsi]\\['
+    'begin': '%q\\['
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal incapable of interpolation -- []'
+    'comment': 'string literal with [] delimitor'
     'end': '\\]'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.lower.ruby'
+    'name': 'string.quoted.other.ruby'
     'patterns': [
       {
         'match': '\\\\\\]|\\\\\\\\'
@@ -818,16 +1254,16 @@
     ]
   }
   {
-    'begin': '%[qwsi]\\{'
+    'begin': '%q\\{'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal incapable of interpolation -- {}'
+    'comment': 'string literal with {} delimitor'
     'end': '\\}'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.lower.ruby'
+    'name': 'string.quoted.other.ruby'
     'patterns': [
       {
         'match': '\\\\\\}|\\\\\\\\'
@@ -839,16 +1275,118 @@
     ]
   }
   {
-    'begin': '%[qwsi]([^\\w])'
+    'begin': '%q([^\\w])'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'literal incapable of interpolation -- wildcard'
+    'comment': 'string literal with wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.literal.lower.ruby'
+    'name': 'string.quoted.other.ruby'
+    'patterns': [
+      {
+        'comment': 'Cant be named because its not neccesarily an escape.'
+        'match': '\\\\.'
+      }
+    ]
+  }
+  {
+    'begin': '%s\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': 'symbol literal with () delimitor'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\)|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_parens'
+      }
+    ]
+  }
+  {
+    'begin': '%s\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': 'symbol literal with <> delimitor'
+    'end': '\\>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\>|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_ltgt'
+      }
+    ]
+  }
+  {
+    'begin': '%s\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': 'symbol literal with [] delimitor'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\]|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_brackets'
+      }
+    ]
+  }
+  {
+    'begin': '%s\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': 'symbol literal with {} delimitor'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
+    'patterns': [
+      {
+        'match': '\\\\\\}|\\\\\\\\'
+        'name': 'constant.character.escape.ruby'
+      }
+      {
+        'include': '#nest_curly'
+      }
+    ]
+  }
+  {
+    'begin': '%s([^\\w])'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.begin.ruby'
+    'comment': 'symbol literal with wildcard delimitor'
+    'end': '\\1'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.symbol.end.ruby'
+    'name': 'constant.other.symbol.ruby'
     'patterns': [
       {
         'comment': 'Cant be named because its not neccesarily an escape.'


### PR DESCRIPTION
This pull request fixes inaccuracies and inconsistencies with the literal grammar.

The goal is to produce grammar that syntax theme authors, like myself, can use to better visually represent the resulting objects of Ruby literals.  And I believe better visual representations will help developers write code with fewer bugs and attain a deeper understanding of the Ruby language. After seeing the before and after screenshots, my hope is that you agree. :)

The changes in this pull request are long so please don't hesitate to ask questions or make suggestions. This pull request also replaces my earlier pull request -- #29 -- and is based on some feedback I received from @nathansobo.
#### %w and %W literal grammar

Before, the grammar parsed these literals as a `String` of `String` tokens.

![1_1](https://cloud.githubusercontent.com/assets/5688/2812802/bac4b7d2-ce6f-11e3-928c-2534e06f93e6.png)

Now, the grammar parses these literals as an `Array` of `String` tokens.

![1_2](https://cloud.githubusercontent.com/assets/5688/2812804/c5a20786-ce6f-11e3-8bd7-36c759a7f4f2.png)
#### %i and %I literal grammar

Before, the grammar parsed these literals as a `String` of `String` tokens.

![2_1](https://cloud.githubusercontent.com/assets/5688/2812806/d92c73b8-ce6f-11e3-8dba-c4677eacc4fa.png)

Now, the grammar parses these literals as an `Array` of `Symbol` tokens.

![2_2](https://cloud.githubusercontent.com/assets/5688/2812808/de305654-ce6f-11e3-9b3a-64ccc0464adb.png)
#### %q, %Q, '', and "" literal grammar

Before, the grammar parsed these literals as `String` tokens.

![3_1](https://cloud.githubusercontent.com/assets/5688/2812810/e6da9d0a-ce6f-11e3-8cf7-b2347d88a2de.png)

And they still do, although now the grammar rules are consistent with the others.
#### %s, %S, :'', and :"" literal grammar

Before, the grammar parsed these literals as either `String` or `Symbol` tokens.

![4_1](https://cloud.githubusercontent.com/assets/5688/2812812/f3056ace-ce6f-11e3-9f40-e3d56427ac9c.png)

Now, the grammar parses these literals as an `Symbol` tokens.  

![4_2](https://cloud.githubusercontent.com/assets/5688/2812813/f736ab26-ce6f-11e3-8129-8f2dadceadda.png)

Note that `%S` doesn't exist in the Ruby language so that grammar has been removed.
#### %r, %R, and // literal grammar

Before, the grammar parsed these literals as either a `String` or a `String` of `RegExp` tokens.

![5_1](https://cloud.githubusercontent.com/assets/5688/2812814/fbbd050a-ce6f-11e3-96db-c4788fca7227.png)

Now, the grammar parses these literals as `RegExp` tokens.  

![5_2](https://cloud.githubusercontent.com/assets/5688/2812815/ff972e58-ce6f-11e3-93c0-18d03a8b2cf5.png)

Note that `%R` doesn't exist in the Ruby language so that grammar has been removed.
