### PR TITLE
Need to specify commentEnd

### DIFF
--- a/scoped-properties/language-ruby.cson
+++ b/scoped-properties/language-ruby.cson
@@ -1,6 +1,7 @@
 '.source.ruby':
   'editor':
     'commentStart': '# '
+    'commentEnd': ''
     'increaseIndentPattern': '(?x)^\n    (\\s*\n        (module|class|def\n        |unless|if|else|elsif\n        |case|when\n        |begin|rescue|ensure\n        |for|while|until\n        |(?= .*? \\b(do|begin|case|if|unless)\\b )\n         # the look-ahead above is to quickly discard non-candidates\n         (  "(\\\\.|[^\\\\"])*+"        # eat a double quoted string\n         | \'(\\\\.|[^\\\\\'])*+\'      # eat a single quoted string\n         |   [^#"\']                # eat all but comments and strings\n         )*\n         (                         \\s   (do|begin|case)\n         | [-+=&|*/~%^<>~](?<!\\$.) \\s*+ (if|unless)\n         )\n        )\\b\n        (?! [^;]*+ ; .*? \\bend\\b )\n    |(  "(\\\\.|[^\\\\"])*+"            # eat a double quoted string\n     | \'(\\\\.|[^\\\\\'])*+\'          # eat a single quoted string\n     |   [^#"\']                    # eat all but comments and strings\n     )*\n     ( \\{ (?!  [^}]*+ \\} )\n     | \\[ (?! [^\\]]*+ \\] )\n     )\n    ).*$'
     'decreaseIndentPattern': '^\\s*([}\\]](,?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)'
 '.text.html.erb':


### PR DESCRIPTION
Otherwise the default is */

Found this while using the copy-to-hipchat plugin, which relies on `editor.commentStart` and `editor.commentEnd`

The comments would look like `# comment */` which was weird.