### PR TITLE
Support &&= as augmented assignment

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1931,7 +1931,7 @@
     'name': 'punctuation.separator.key-value'
   }
   {
-    'match': '<<=|%=|&=|\\*=|\\*\\*=|\\+=|\\-=|\\^=|\\|{1,2}=|<<'
+    'match': '<<=|%=|&{1,2}=|\\*=|\\*\\*=|\\+=|\\-=|\\^=|\\|{1,2}=|<<'
     'name': 'keyword.operator.assignment.augmented.ruby'
   }
   {


### PR DESCRIPTION
Support `&&=` as augmented assignment

This is to match `||=`, `|=`, and `&=`.
