### PR TITLE
Support Emacs file mode comments

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -31,7 +31,7 @@
   'Thorfile'
   'Vagrantfile'
 ]
-'firstLineMatch': '^#!\\s*/.*\\bruby'
+'firstLineMatch': '^#!\\s*/.*\\bruby|^#\\s+-\\*-\\s*ruby\\s*-\\*-",
 'patterns': [
   {
     'captures':

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -31,7 +31,7 @@
   'Thorfile'
   'Vagrantfile'
 ]
-'firstLineMatch': '^#!\\s*/.*\\bruby|^#\\s+-\\*-\\s*ruby\\s*-\\*-",
+'firstLineMatch': '^#!\\s*/.*\\bruby|^#\\s+-\\*-\\s*ruby\\s*-\\*-'
 'patterns': [
   {
     'captures':


### PR DESCRIPTION
Files starting with a comment line of the form:

    # -*- ruby -*-

should be recognised as Ruby source. This “standard” originates from [Emacs], but is also used by others

[Emacs]: http://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html