### PR TITLE
Fix/regex suffix parsing

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -496,7 +496,7 @@
     ]
   }
   {
-    'begin': '(?<![\\w)])((/))(?![*+?])(?=(?:\\\\/|[^/])*/[eimnosux]*\\s*([\\]#).,?:}]|$|\\|\\||&&))'
+    'begin': '(?<![\\w)])((/))(?![*+?])(?=(?:\\\\/|[^/])*/[eimnosux]*\\s*([\\]#).,?:}]|$|\\|\\||&&|<=>|=>|==|=~|!~|!=|;|if|else|elsif|then|do|end|unless|while|until|or|and))'
     'captures':
       '1':
         'name': 'string.regexp.interpolated.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -188,6 +188,169 @@ describe "Ruby grammar", ->
     expect(tokens[5]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
     expect(tokens[6]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
 
+    {tokens} = grammar.tokenizeLine('if "test" =~ /test/ then 4 end')
+
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[9]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[10]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[11]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[12]).toEqual value: 'then', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('if "test" =~ /test/; 4 end')
+
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[9]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[10]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[11]).toEqual value: ';', scopes: ['source.ruby', 'punctuation.separator.statement.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ =~ "test"')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: '=~', scopes: ['source.ruby', 'keyword.operator.comparison.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ !~ "test"')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: '!~', scopes: ['source.ruby', 'keyword.operator.comparison.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ != "test"')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: '!=', scopes: ['source.ruby', 'keyword.operator.comparison.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ == /test/')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: '==', scopes: ['source.ruby', 'keyword.operator.comparison.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[7]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ === /test/')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: '===', scopes: ['source.ruby', 'keyword.operator.comparison.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[7]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+
+    {tokens} = grammar.tokenizeLine('if false then /test/ else 4 end')
+
+    expect(tokens[4]).toEqual value: 'then', scopes: ['source.ruby', 'keyword.control.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[7]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[9]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[10]).toEqual value: 'else', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('if false then 4 else /test/ end')
+
+    expect(tokens[8]).toEqual value: 'else', scopes: ['source.ruby', 'keyword.control.ruby']
+    expect(tokens[9]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[10]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[11]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[12]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[13]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[14]).toEqual value: 'end', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('if true then /test/ elsif false then 4 end')
+
+    expect(tokens[4]).toEqual value: 'then', scopes: ['source.ruby', 'keyword.control.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[7]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[8]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[9]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[10]).toEqual value: 'elsif', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('method /test/ do; end')
+
+    expect(tokens[1]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[3]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[5]).toEqual value: 'do', scopes: ['source.ruby', 'keyword.control.start-block.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ if true')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'if', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ unless true')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'unless', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ while true')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'while', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ until true')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'until', scopes: ['source.ruby', 'keyword.control.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ or return')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'or', scopes: ['source.ruby', 'keyword.operator.logical.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: 'return', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
+
+    {tokens} = grammar.tokenizeLine('/test/ and return')
+
+    expect(tokens[0]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[4]).toEqual value: 'and', scopes: ['source.ruby', 'keyword.operator.logical.ruby']
+    expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[6]).toEqual value: 'return', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
+
+    {tokens} = grammar.tokenizeLine('{/test/ => 1}')
+
+    expect(tokens[1]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
+    expect(tokens[3]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[5]).toEqual value: '=>', scopes: ['source.ruby', 'punctuation.separator.key-value']
+    expect(tokens[6]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[7]).toEqual value: '1', scopes: ['source.ruby', 'constant.numeric.ruby']
+
   it "tokenizes the / arithmetic operator", ->
     {tokens} = grammar.tokenizeLine('call/me/maybe')
     expect(tokens[0]).toEqual value: 'call', scopes: ['source.ruby']
@@ -195,7 +358,6 @@ describe "Ruby grammar", ->
     expect(tokens[2]).toEqual value: 'me', scopes: ['source.ruby']
     expect(tokens[3]).toEqual value: '/', scopes: ['source.ruby', 'keyword.operator.arithmetic.ruby']
     expect(tokens[4]).toEqual value: 'maybe', scopes: ['source.ruby']
-
 
     {tokens} = grammar.tokenizeLine('(1+2)/3/4')
     expect(tokens[0]).toEqual value: '(', scopes: ['source.ruby', 'punctuation.section.function.ruby']
@@ -238,6 +400,15 @@ describe "Ruby grammar", ->
     expect(tokens[5]).toEqual value: '/', scopes: ['source.ruby', 'keyword.operator.arithmetic.ruby']
     expect(tokens[6]).toEqual value: ' ', scopes: ['source.ruby']
     expect(tokens[7]).toEqual value: '3', scopes: ['source.ruby', 'constant.numeric.ruby']
+
+    {tokens} = grammar.tokenizeLine('x / 2; x /= 2')
+    expect(tokens[1]).toEqual value: '/', scopes: ['source.ruby', 'keyword.operator.arithmetic.ruby']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[3]).toEqual value: '2', scopes: ['source.ruby', 'constant.numeric.ruby']
+    expect(tokens[4]).toEqual value: ';', scopes: ['source.ruby', 'punctuation.separator.statement.ruby']
+    expect(tokens[6]).toEqual value: '/=', scopes: ['source.ruby', 'keyword.operator.assignment.augmented.ruby']
+    expect(tokens[7]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[8]).toEqual value: '2', scopes: ['source.ruby', 'constant.numeric.ruby']
 
   it "tokenizes yard documentation comments", ->
     {tokens} = grammar.tokenizeLine('# @private')


### PR DESCRIPTION
Tokens are only highlighted as regex if they are followed by a certain non-exhaustive set of characters. This commit adds some characters and keywords to that set that should yield a regex. 

Addresses #92, example images are located there.