### PR TITLE
Add curly braces block snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -303,6 +303,9 @@
   'pry':
     'prefix': 'pry'
     'body': 'binding.pry'
+  'Insert curly braces block':
+    'prefix': '{'
+    'body': '{ ${1:|${2:variable}|} $0 '
 '.source.ruby .comment':
   ':yields:':
     'prefix': 'y'


### PR DESCRIPTION
This adds a snippet that behaves like the "Insert do |variable| … end" snippet, but adds a block with curly braces syntax. It works in combination with the bracket-matcher package that autocompletes the closing curly brace.