### PR TITLE
Fix/require highlighting

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -139,7 +139,7 @@
     'name': 'keyword.other.special-method.ruby'
   }
   {
-    'begin': '\\b(require|require_relative|gem)\\b'
+    'begin': '\\b(?<!\\.|::)(require|require_relative|gem)\\b'
     'captures':
       '1':
         'name': 'keyword.other.special-method.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -16,6 +16,19 @@ describe "Ruby grammar", ->
     {tokens} = grammar.tokenizeLine('self')
     expect(tokens[0]).toEqual value: 'self', scopes: ['source.ruby', 'variable.language.self.ruby']
 
+  it "tokenizes special functions", ->
+    {tokens} = grammar.tokenizeLine('require "."')
+    expect(tokens[0]).toEqual value: 'require', scopes: ['source.ruby', 'meta.require.ruby', 'keyword.other.special-method.ruby']
+
+    {tokens} = grammar.tokenizeLine('Kernel.require "."')
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: 'require ', scopes: ['source.ruby']
+
+    {tokens} = grammar.tokenizeLine('Kernel::require "."')
+    expect(tokens[1]).toEqual value: ':', scopes: ['source.ruby', 'punctuation.separator.other.ruby']
+    expect(tokens[2]).toEqual value: ':', scopes: ['source.ruby', 'punctuation.separator.other.ruby']
+    expect(tokens[3]).toEqual value: 'require ', scopes: ['source.ruby']
+
   it "tokenizes symbols", ->
     {tokens} = grammar.tokenizeLine(':test')
     expect(tokens[0]).toEqual value: ':', scopes: ['source.ruby', 'constant.other.symbol.ruby', 'punctuation.definition.constant.ruby']


### PR DESCRIPTION
~~Two potential changes here.~~

1. `require` should only be highlighted as a special method if it's not called on an object. Use negative lookbehind to check if it's preceded by `.` or `::`. 

~~2. `::` should be preferred in the grammar over `:`. Otherwise the double colons in `Kernel::require` are improperly assigned the 'punctuation.separator.other.ruby' scope instead of the 'punctuation.separator.method.ruby' scope.~~

Before:
![screen shot 2015-05-21 at 8 29 23 pm](https://cloud.githubusercontent.com/assets/2596124/7761917/4493548e-fffa-11e4-9800-9f663ef721a7.png)

After:
![screen shot 2015-05-21 at 8 35 06 pm](https://cloud.githubusercontent.com/assets/2596124/7761921/49f44e56-fffa-11e4-8b27-a25467ac0df1.png)
