### PR TITLE
Feature/add constant separator

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1971,8 +1971,16 @@
     'name': 'punctuation.separator.object.ruby'
   }
   {
-    'match': '\\.|::'
-    'name': 'punctuation.separator.method.ruby'
+    'match': '(::)\\s*(?=[A-Z])'
+    'captures':
+      '1':
+        'name': 'punctuation.separator.namespace.ruby'
+  }
+  {
+    'match': '(\\.|::)\\s*(?![A-Z])'
+    'captures':
+      '1':
+        'name': 'punctuation.separator.method.ruby'
   }
   {
     'match': ':'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1971,18 +1971,21 @@
     'name': 'punctuation.separator.object.ruby'
   }
   {
+    'comment': 'Mark as namespace separator if double colons followed by capital letter'
     'match': '(::)\\s*(?=[A-Z])'
     'captures':
       '1':
         'name': 'punctuation.separator.namespace.ruby'
   }
   {
+    'comment': 'Mark as method separator if double colons not followed by capital letter'
     'match': '(\\.|::)\\s*(?![A-Z])'
     'captures':
       '1':
         'name': 'punctuation.separator.method.ruby'
   }
   {
+    'comment': 'Must come after method and constant separators to prefer double colons'
     'match': ':'
     'name': 'punctuation.separator.other.ruby'
   }

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1963,10 +1963,6 @@
     'name': 'keyword.operator.other.ruby'
   }
   {
-    'match': ':'
-    'name': 'punctuation.separator.other.ruby'
-  }
-  {
     'match': '\\;'
     'name': 'punctuation.separator.statement.ruby'
   }
@@ -1977,6 +1973,10 @@
   {
     'match': '\\.|::'
     'name': 'punctuation.separator.method.ruby'
+  }
+  {
+    'match': ':'
+    'name': 'punctuation.separator.other.ruby'
   }
   {
     'match': '\\{'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -25,9 +25,8 @@ describe "Ruby grammar", ->
     expect(tokens[2]).toEqual value: 'require ', scopes: ['source.ruby']
 
     {tokens} = grammar.tokenizeLine('Kernel::require "."')
-    expect(tokens[1]).toEqual value: ':', scopes: ['source.ruby', 'punctuation.separator.other.ruby']
-    expect(tokens[2]).toEqual value: ':', scopes: ['source.ruby', 'punctuation.separator.other.ruby']
-    expect(tokens[3]).toEqual value: 'require ', scopes: ['source.ruby']
+    expect(tokens[1]).toEqual value: '::', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: 'require ', scopes: ['source.ruby']
 
   it "tokenizes symbols", ->
     {tokens} = grammar.tokenizeLine(':test')
@@ -57,6 +56,41 @@ describe "Ruby grammar", ->
     expect(tokens[3]).toEqual value: '=>', scopes: ['source.ruby', 'punctuation.separator.key-value']
     expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby']
     expect(tokens[5]).toEqual value: '1', scopes: ['source.ruby', 'constant.numeric.ruby']
+
+  it "tokenizes :: separators", ->
+    {tokens} = grammar.tokenizeLine('File::read "test"')
+    expect(tokens[0]).toEqual value: 'File', scopes: ['source.ruby', 'support.class.ruby']
+    expect(tokens[1]).toEqual value: '::', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: 'read ', scopes: ['source.ruby']
+
+    {tokens} = grammar.tokenizeLine('File:: read "test"')
+    expect(tokens[0]).toEqual value: 'File', scopes: ['source.ruby', 'variable.other.constant.ruby']
+    expect(tokens[1]).toEqual value: '::', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[3]).toEqual value: 'read ', scopes: ['source.ruby']
+
+    {tokens} = grammar.tokenizeLine('RbConfig::CONFIG')
+    expect(tokens[0]).toEqual value: 'RbConfig', scopes: ['source.ruby', 'support.class.ruby']
+    expect(tokens[1]).toEqual value: '::', scopes: ['source.ruby', 'punctuation.separator.namespace.ruby']
+    expect(tokens[2]).toEqual value: 'CONFIG', scopes: ['source.ruby', 'variable.other.constant.ruby']
+
+    {tokens} = grammar.tokenizeLine('RbConfig:: CONFIG')
+    expect(tokens[0]).toEqual value: 'RbConfig', scopes: ['source.ruby', 'variable.other.constant.ruby']
+    expect(tokens[1]).toEqual value: '::', scopes: ['source.ruby', 'punctuation.separator.namespace.ruby']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[3]).toEqual value: 'CONFIG', scopes: ['source.ruby', 'variable.other.constant.ruby']
+
+  it "tokenizes . separator", ->
+    {tokens} = grammar.tokenizeLine('File.read "test"')
+    expect(tokens[0]).toEqual value: 'File', scopes: ['source.ruby', 'support.class.ruby']
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: 'read ', scopes: ['source.ruby']
+
+    {tokens} = grammar.tokenizeLine('File. read "test"')
+    expect(tokens[0]).toEqual value: 'File', scopes: ['source.ruby', 'variable.other.constant.ruby']
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['source.ruby']
+    expect(tokens[3]).toEqual value: 'read ', scopes: ['source.ruby']
 
   it "tokenizes %{} style strings", ->
     {tokens} = grammar.tokenizeLine('%{te{s}t}')


### PR DESCRIPTION
Currently there are two issues with the '::' token in the Ruby grammar. 

1. ":" is preferred over "::", so "::" method separators are always erroneously marked with the 'punctuation.separator.other.ruby' scope instead of 'punctuation.separator.method.ruby'.
2. "::" isn't always a method separator in Ruby, it's also allows you to access module hierarchies and other constants. Constants are signified by starting with a capital letter. Solution is to create a new scope 'punctuation.separator.constant.ruby' that looks ahead to see if the next letter is a capital. 