### PR TITLE
Add Schemafile

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -27,6 +27,7 @@
   'rjs'
   'ru'
   'ruby'
+  'Schemafile'
   'thor'
   'Thorfile'
   'Vagrantfile'


### PR DESCRIPTION
I need that Schemafile is syntax highlighting of ruby :gem: .
Schemafile is defined by winebarrel/ridgepole, it is a tool to manage the DB schema.

https://github.com/winebarrel/ridgepole