### PR TITLE
Use unique prefixes in snippets

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -22,13 +22,13 @@
     'prefix': 'bm-'
     'body': 'TESTS = ${1:10_000}\nBenchmark.bmbm do |results|\n  $0\nend'
   'Dir.glob("..") { |file| .. }':
-    'prefix': 'Dir'
+    'prefix': 'Dirg'
     'body': 'Dir.glob(${1:"${2:dir/glob/*}"}) { |${3:file}| $0 }'
   'Dir[".."]':
     'prefix': 'Dir'
     'body': 'Dir[${1:"${2:glob/**/*.rb}"}]'
   'File.foreach ("..") { |line| .. }':
-    'prefix': 'File'
+    'prefix': 'Filef'
     'body': 'File.foreach(${1:"${2:path/to/file}"}) { |${3:line}| $0 }'
   'File.read("..")':
     'prefix': 'File'
@@ -91,10 +91,10 @@
     'prefix': 'w'
     'body': 'attr_writer :${0:attr_names}'
   'ClassName = Struct .. do .. end':
-    'prefix': 'cla'
+    'prefix': 'clast'
     'body': '$1 = Struct.new(:${2:attr_names}) do\n\tdef ${3:method_name}\n\t\t$0\n\tend\n\t\n\t\nend'
   'class << self .. end':
-    'prefix': 'cla'
+    'prefix': 'clase'
     'body': 'class << ${1:self}\n\t$0\nend'
   'class .. end':
     'prefix': 'cla'
@@ -151,10 +151,10 @@
     'prefix': 'eab'
     'body': 'each_byte { |${1:byte}| $0 }'
   'each_char { |chr| .. }':
-    'prefix': 'eac-'
+    'prefix': 'eacha'
     'body': 'each_char { |${1:chr}| $0 }'
   'each_cons(..) { |group| .. }':
-    'prefix': 'eac-'
+    'prefix': 'eacon'
     'body': 'each_cons(${1:2}) { |${2:group}| $0 }'
   'each_index { |i| .. }':
     'prefix': 'eai'
@@ -220,7 +220,7 @@
     'prefix': 'min'
     'body': 'min { |a, b| $0 }'
   'module .. module_function .. end':
-    'prefix': 'mod'
+    'prefix': 'modf'
     'body': 'module $1\n\tmodule_function\n\t\n\t$0\nend'
   'module .. end':
     'prefix': 'mod'


### PR DESCRIPTION
Fixes https://github.com/atom/language-ruby/issues/14.

I did my best to pick reasonable prefixes for those which were dupes, but let me know if there's something else that would make more sense. :book:

cc @kevinsawicki and @miketheman for :eyes: since you were discussing this in https://github.com/atom/language-ruby/issues/14, and also cc @atom/feedback. 