### PR TITLE
Update language-ruby.cson

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -230,7 +230,7 @@
               '1':
                 'name': 'storage.type.variable.ruby'
               '2':
-                'name': 'constant.other.symbol.hashkey.ruby'
+                'name': 'constant.other.symbol.hashkey.parameter.function.ruby'
               '3':
                 'name': 'punctuation.definition.constant.hashkey.ruby'
               '4':
@@ -264,7 +264,7 @@
               '1':
                 'name': 'storage.type.variable.ruby'
               '2':
-                'name': 'constant.other.symbol.hashkey.ruby'
+                'name': 'constant.other.symbol.hashkey.parameter.function.ruby'
               '3':
                 'name': 'punctuation.definition.constant.hashkey.ruby'
               '4':

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -223,7 +223,7 @@
     'patterns': [
       {
         'begin': '(?![\\s,)])'
-        'end': '(?=[,)])'
+        'end': '(?=\\,|\\)\\s*$)'
         'patterns': [
           {
             'captures':

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1924,8 +1924,11 @@
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'
-    'end': '(\\|)'
+    'end': '([^\\|]([\\|])[^\\|])'
     'patterns': [
+      {
+        'include': 'source.ruby'
+      }
       {
         'match': '[_a-zA-Z][_a-zA-Z0-9]*'
         'name': 'variable.other.block.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1896,12 +1896,12 @@
     ]
   }
   {
-    'begin': '(?><<-(\\w+))'
+    'begin': '(?>((<<-(\\w+),\\s?)*<<-(\\w+)))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'heredoc with indented terminator'
-    'end': '\\s*\\1$'
+    'comment': 'heredoc with multiple inputs and indented terminator'
+    'end': '\\s*\\4$'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -258,9 +258,10 @@
           {
             'captures':
               '1':
-                'name': 'punctuation.definition.variable.ruby'
-            'match': '\\G([&*]?)[_a-zA-Z][_a-zA-Z0-9]*'
-            'name': 'variable.parameter.function.ruby'
+                'name': 'storage.type.variable.ruby'
+              '2':
+                'name': 'variable.parameter.function.ruby'
+            'match': '\\G([&*]?)([_a-zA-Z][_a-zA-Z0-9]*)'
           }
           {
             'include': '$self'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -230,8 +230,12 @@
               '1':
                 'name': 'storage.type.variable.ruby'
               '2':
+                'name': 'constant.other.symbol.hashkey.ruby'
+              '3':
+                'name': 'punctuation.definition.constant.hashkey.ruby'
+              '4':
                 'name': 'variable.parameter.function.ruby'
-            'match': '\\G([&*]?)([_a-zA-Z][_a-zA-Z0-9]*)'
+            'match': '\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))'
           }
           {
             'include': '$self'
@@ -260,8 +264,12 @@
               '1':
                 'name': 'storage.type.variable.ruby'
               '2':
+                'name': 'constant.other.symbol.hashkey.ruby'
+              '3':
+                'name': 'punctuation.definition.constant.hashkey.ruby'
+              '4':
                 'name': 'variable.parameter.function.ruby'
-            'match': '\\G([&*]?)([_a-zA-Z][_a-zA-Z0-9]*)'
+            'match': '\\G([&*]?)(?:([_a-zA-Z]\\w*(:))|([_a-zA-Z]\\w*))'
           }
           {
             'include': '$self'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1952,6 +1952,10 @@
     'name': 'punctuation.separator.key-value'
   }
   {
+    'match': '->'
+    'name': 'keyword.operator.lambda.ruby'
+  }
+  {
     'match': '<<=|%=|&{1,2}=|\\*=|\\*\\*=|\\+=|\\-=|\\^=|\\|{1,2}=|<<'
     'name': 'keyword.operator.assignment.augmented.ruby'
   }

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1953,7 +1953,7 @@
   }
   {
     'match': '->'
-    'name': 'keyword.operator.lambda.ruby'
+    'name': 'support.function.kernel.ruby'
   }
   {
     'match': '<<=|%=|&{1,2}=|\\*=|\\*\\*=|\\+=|\\-=|\\^=|\\|{1,2}=|<<'

--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -115,8 +115,8 @@
     'prefix': 'def'
     'body': 'def ${1:method_name}\n\t$0\nend'
   'initialize':
-    'prefix': 'init'
-    'body': 'def initialize${1:(${2:argument})}\n\t$0\nend'
+    'prefix': 'defi'
+    'body': 'def initialize${1:(${2:argument})}\n\t\@${2:argument} = ${2:argument}$0\nend'
   'def method_missing .. end':
     'prefix': 'defmm'
     'body': 'def method_missing(meth, *args, &blk)\n\t$0\nend'

--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -320,6 +320,18 @@
   'erb_render_block':
     'prefix': '='
     'body': '<%= $1 %>'
+  'erb_render_block_after_tag':
+    'prefix': '\>='
+    'body': '\><%= $1 %>'
+  'erb_render_block_after_quote':
+    'prefix': '\"='
+    'body': '\"<%= $1 %>'
   'erb_exec_block':
     'prefix': '-'
     'body': '<% $1 %>'
+  'erb_exec_block_after_tag':
+    'prefix': '\>-'
+    'body': '\><% $1 %>'
+  'erb_exec_block_after_quote':
+    'prefix': '\"-'
+    'body': '\"<% $1 %>'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -535,47 +535,47 @@ describe "Ruby grammar", ->
 
   it "tokenizes a method with *args properly", ->
     {tokens} = grammar.tokenizeLine('def method(*args)')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
-    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
-    expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
+    expect(tokens[4]).toEqual value: '*', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby']
     expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
     expect(tokens[6]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
 
     {tokens} = grammar.tokenizeLine('def method(args)')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
-    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
     expect(tokens[4]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
     expect(tokens[5]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
 
     {tokens} = grammar.tokenizeLine('def method *args')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
-    expect(tokens[3]).toEqual value: ' ', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby']
-    expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
+    expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby']
+    expect(tokens[4]).toEqual value: '*', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby']
     expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
 
   it "tokenizes a method with (symbol: arg) properly", ->
     {tokens} = grammar.tokenizeLine('def method(red: 2)')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
-    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
 
   it "tokenizes a method with symbol: arg (no paren) properly", ->
     {tokens} = grammar.tokenizeLine('def method red: 2')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
 
   it "tokenizes a method with (symbol: arg(paren), symbol: arg2(paren)...) properly", ->
     {tokens} = grammar.tokenizeLine('def method(red: rand(2), green: rand(3), blue: rand(4))')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
-    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
@@ -585,7 +585,7 @@ describe "Ruby grammar", ->
 
   it "tokenizes a method with symbol: arg(paren), symbol: arg2(paren)... (no outer parens) properly", ->
     {tokens} = grammar.tokenizeLine('def method red: rand(2), green: rand(3), blue: rand(4)')
-    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby']
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
@@ -596,4 +596,4 @@ describe "Ruby grammar", ->
 
   it "tokenizes a stabby lambda properly", ->
     {tokens} = grammar.tokenizeLine('method_name -> { puts "A message"} do')
-    expect(tokens[1]).toEqual value: '->', scopes: [ 'source.ruby', 'keyword.operator.lambda.ruby' ]
+    expect(tokens[1]).toEqual value: '->', scopes: ['source.ruby', 'keyword.operator.lambda.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -555,3 +555,15 @@ describe "Ruby grammar", ->
     expect(tokens[3]).toEqual value: ' ', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby']
     expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
     expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+
+  it "tokenizes a method with (symbol: arg(paren), symbol: arg2(paren)...) properly", ->
+    {tokens} = grammar.tokenizeLine('def method(red: rand(2), green: rand(3), blue: rand(4))')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -561,7 +561,14 @@ describe "Ruby grammar", ->
     expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
-    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
+    expect(tokens[7]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+
+  it "tokenizes a method with symbol: arg (no paren) properly", ->
+    {tokens} = grammar.tokenizeLine('def method red: 2')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
 
   it "tokenizes a method with (symbol: arg(paren), symbol: arg2(paren)...) properly", ->
@@ -569,9 +576,20 @@ describe "Ruby grammar", ->
     expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
-    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
-    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
+    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
+    expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+
+  it "tokenizes a method with symbol: arg(paren), symbol: arg2(paren)... (no outer parens) properly", ->
+    {tokens} = grammar.tokenizeLine('def method red: rand(2), green: rand(3), blue: rand(4)')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
+    expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -578,10 +578,19 @@ describe "Ruby grammar", ->
     expect(tokens[3]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[8]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[10]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[16]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[20]).toEqual value: 'blue', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
+    expect(tokens[23]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[24]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[25]).toEqual value: '4', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[26]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
 
   it "tokenizes a method with symbol: arg(paren), symbol: arg2(paren)... (no outer parens) properly", ->
     {tokens} = grammar.tokenizeLine('def method red: rand(2), green: rand(3), blue: rand(4)')
@@ -589,10 +598,19 @@ describe "Ruby grammar", ->
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[8]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[10]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[16]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
     expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[20]).toEqual value: 'blue', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
+    expect(tokens[23]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
+    expect(tokens[24]).toEqual value: '(', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[25]).toEqual value: '4', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+    expect(tokens[26]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.section.function.ruby']
 
   it "tokenizes a stabby lambda properly", ->
     {tokens} = grammar.tokenizeLine('method_name -> { puts "A message"} do')

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -614,4 +614,4 @@ describe "Ruby grammar", ->
 
   it "tokenizes a stabby lambda properly", ->
     {tokens} = grammar.tokenizeLine('method_name -> { puts "A message"} do')
-    expect(tokens[1]).toEqual value: '->', scopes: ['source.ruby', 'keyword.operator.lambda.ruby']
+    expect(tokens[1]).toEqual value: '->', scopes: ['source.ruby', 'support.function.kernel.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -532,3 +532,26 @@ describe "Ruby grammar", ->
     expect(tokens[6]).toEqual value: 'Array#[](0), Array', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
     expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
     expect(tokens[8]).toEqual value: ' comment', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+
+  it "tokenizes a method with *args properly", ->
+    {tokens} = grammar.tokenizeLine('def method(*args)')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
+    expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[6]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
+
+    {tokens} = grammar.tokenizeLine('def method(args)')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[4]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[5]).toEqual value: ')', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby']
+
+    {tokens} = grammar.tokenizeLine('def method *args')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[3]).toEqual value: ' ', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby']
+    expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
+    expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -556,14 +556,22 @@ describe "Ruby grammar", ->
     expect(tokens[4]).toEqual value: '*', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'storage.type.variable.ruby' ]
     expect(tokens[5]).toEqual value: 'args', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
 
+  it "tokenizes a method with (symbol: arg) properly", ->
+    {tokens} = grammar.tokenizeLine('def method(red: 2)')
+    expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
+    expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
+    expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
+    expect(tokens[7]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+
   it "tokenizes a method with (symbol: arg(paren), symbol: arg2(paren)...) properly", ->
     {tokens} = grammar.tokenizeLine('def method(red: rand(2), green: rand(3), blue: rand(4))')
     expect(tokens[0]).toEqual value: 'def', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'keyword.control.def.ruby' ]
     expect(tokens[2]).toEqual value: 'method', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'entity.name.function.ruby']
     expect(tokens[3]).toEqual value: '(', scopes: [ 'source.ruby', 'meta.function.method.with-arguments.ruby', 'punctuation.definition.parameters.ruby' ]
-    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[4]).toEqual value: 'red', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
     expect(tokens[7]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[9]).toEqual value: '2', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
-    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'variable.parameter.function.ruby']
+    expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.ruby']
     expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -593,3 +593,7 @@ describe "Ruby grammar", ->
     expect(tokens[12]).toEqual value: 'green', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.other.symbol.hashkey.parameter.function.ruby']
     expect(tokens[15]).toEqual value: 'rand', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'support.function.kernel.ruby']
     expect(tokens[17]).toEqual value: '3', scopes: ['source.ruby', 'meta.function.method.with-arguments.ruby', 'constant.numeric.ruby']
+
+  it "tokenizes a stabby lambda properly", ->
+    {tokens} = grammar.tokenizeLine('method_name -> { puts "A message"} do')
+    expect(tokens[1]).toEqual value: '->', scopes: [ 'source.ruby', 'keyword.operator.lambda.ruby' ]


### PR DESCRIPTION
- Changed 'initialize' prefix to unique 'defi' and added multiple cursor for assignment of instance variable with same name as argument.
- Modified 'heredoc with indented terminator' to 'heredoc with optional multiple inputs and indented terminators'
- Fix for issue where erb blocks would not expand after an HTML tag 
- Fix for formatting of def method *args
- Fix for `||` pipes within block arguments
- Fix for multiple method arguments
- Added grammar styling for symbol hashkeys within method parameters
- Added grammar styling for stabby lambda (->) operator