### PR TITLE
Fine tune curly braces block

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -311,7 +311,7 @@
     'body': 'binding.pry'
   'Insert curly braces block':
     'prefix': '{'
-    'body': '{ ${1:|${2:variable}|} $0 '
+    'body': '{ ${1:|${2:variable}| }$0 '
 '.source.ruby .comment':
   ':yields:':
     'prefix': 'y'


### PR DESCRIPTION
This snippet allows for two different usages:

1. We want a block with variable:
   All we have to do is enter a `{`, tab twice, edit the variable name,
   tab again and write what's inside the block.

2. We want a block without variable, but with spaces inside the braces:
   So we enter a `{`, tab once and start to write whats inside the
   block.

Before, the latter usage resulted in the following:
`{<space>mycodeinsidetheblock<space><space>}`
This commit removes the second space before the closing brace.