### PR TITLE
Improve class/module snippets. Add begin/rescue/end snippets.

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -15,6 +15,9 @@
   'case … end':
     'prefix': 'case'
     'body': 'case ${1:object}\nwhen ${2:condition}\n\t$0\nend'
+  'begin … rescue … end':
+    'prefix': 'bre'
+    'body': 'begin\n\t\nrescue ${1:ExceptionName}\n\t\nend'
   'Add ‘# =>’ Marker':
     'prefix': '#'
     'body': '# => '
@@ -98,7 +101,7 @@
     'body': 'class << ${1:self}\n\t$0\nend'
   'class .. end':
     'prefix': 'cla'
-    'body': 'class $1\n\t$0\nend'
+    'body': 'class ${1:ClassName}\n\t$0\nend'
   'class_from_name()':
     'prefix': 'clafn'
     'body': 'split("::").inject(Object) { |par, const| par.const_get(const) }'
@@ -227,7 +230,7 @@
     'body': 'module $1\n\tmodule_function\n\t\n\t$0\nend'
   'module .. end':
     'prefix': 'mod'
-    'body': 'module $1\n\t$0\nend'
+    'body': 'module ${1:ModuleName}\n\t$0\nend'
   'namespace :.. do .. end':
     'prefix': 'nam'
     'body': 'namespace :$1 do\n\t$0\nend'

--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -17,7 +17,7 @@
     'body': 'case ${1:object}\nwhen ${2:condition}\n\t$0\nend'
   'begin … rescue … end':
     'prefix': 'bre'
-    'body': 'begin\n\t\nrescue ${1:ExceptionName}\n\t\nend'
+    'body': 'begin\n\t$1\nrescue ${2:ExceptionName}\n\t$3\nend'
   'Add ‘# =>’ Marker':
     'prefix': '#'
     'body': '# => '

--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -16,7 +16,7 @@
     'prefix': 'case'
     'body': 'case ${1:object}\nwhen ${2:condition}\n\t$0\nend'
   'begin … rescue … end':
-    'prefix': 'bre'
+    'prefix': 'beg'
     'body': 'begin\n\t$1\nrescue ${2:ExceptionName}\n\t$3\nend'
   'Add ‘# =>’ Marker':
     'prefix': '#'


### PR DESCRIPTION
This pull request is in two parts. I can separate it easily if desired.

The first part is a slight improvement to the class (cla) and module (mod) snippets. I'm not 100% sure what it's called, but it adds a default "ClassName" or "ModuleName" (like if statement snippets "condition") accordingly.

The second part is the added `begin ... rescue ... end` snippet. It works just like the `if ... else ... end` snippet, except that it adds one of those fancy default "ExceptionName" things.

This commit should finally close #85.