### PR TITLE
Fixes blockpipe formatting

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1936,7 +1936,7 @@
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'
-    'end': '(?<=[^\\|])(\\|)(?=[^\\|])'
+    'end': '(?<!\\|)(\\|)(?!\\|)'
     'patterns': [
       {
         'include': 'source.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1936,7 +1936,7 @@
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'
-    'end': '(?<=[^\|])([\|])(?=[^\|])'
+    'end': '(?<=[^\\|])([\\|])(?=[^\\|])'
     'patterns': [
       {
         'include': 'source.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1936,7 +1936,7 @@
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'
-    'end': '([^\\|]([\\|])[^\\|])'
+    'end': '(?<=[^\|])([\|])(?=[^\|])'
     'patterns': [
       {
         'include': 'source.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1936,7 +1936,7 @@
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'
-    'end': '(?<=[^\\|])([\\|])(?=[^\\|])'
+    'end': '(?<=[^\\|])(\\|)(?=[^\\|])'
     'patterns': [
       {
         'include': 'source.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -615,3 +615,31 @@ describe "Ruby grammar", ->
   it "tokenizes a stabby lambda properly", ->
     {tokens} = grammar.tokenizeLine('method_name -> { puts "A message"} do')
     expect(tokens[1]).toEqual value: '->', scopes: ['source.ruby', 'support.function.kernel.ruby']
+
+  it "tokenizes a simple do block properly", ->
+    {tokens} = grammar.tokenizeLine('do |foo| ')
+    expect(tokens[0]).toEqual value: 'do ', scopes: ['source.ruby', 'keyword.control.start-block.ruby']
+    expect(tokens[1]).toEqual value: '|', scopes: ['source.ruby', 'punctuation.separator.variable.ruby']
+    expect(tokens[2]).toEqual value: 'foo', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[3]).toEqual value: '|', scopes: ['source.ruby', 'punctuation.separator.variable.ruby']
+
+  it "tokenizes a complex do block properly", ->
+    {tokens} = grammar.tokenizeLine('do |key = (a || b), hash = config, create: false|')
+    expect(tokens[0]).toEqual value: 'do ', scopes: ['source.ruby', 'keyword.control.start-block.ruby']
+    expect(tokens[1]).toEqual value: '|', scopes: ['source.ruby', 'punctuation.separator.variable.ruby']
+    expect(tokens[2]).toEqual value: 'key', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[4]).toEqual value: '=', scopes: ['source.ruby', 'keyword.operator.assignment.ruby']
+    expect(tokens[6]).toEqual value: '(', scopes: ['source.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[7]).toEqual value: 'a', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[9]).toEqual value: '||', scopes: ['source.ruby', 'keyword.operator.logical.ruby']
+    expect(tokens[11]).toEqual value: 'b', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[12]).toEqual value: ')', scopes: ['source.ruby', 'punctuation.section.function.ruby']
+    expect(tokens[13]).toEqual value: ',', scopes: ['source.ruby', 'punctuation.separator.object.ruby']
+    expect(tokens[15]).toEqual value: 'hash', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[17]).toEqual value: '=', scopes: ['source.ruby', 'keyword.operator.assignment.ruby']
+    expect(tokens[19]).toEqual value: 'config', scopes: ['source.ruby', 'variable.other.block.ruby']
+    expect(tokens[20]).toEqual value: ',', scopes: ['source.ruby', 'punctuation.separator.object.ruby']
+    expect(tokens[22]).toEqual value: 'create', scopes: ['source.ruby', 'constant.other.symbol.hashkey.ruby']
+    expect(tokens[23]).toEqual value: ':', scopes: ['source.ruby', 'constant.other.symbol.hashkey.ruby', 'punctuation.definition.constant.hashkey.ruby']
+    expect(tokens[25]).toEqual value: 'false', scopes: ['source.ruby', 'constant.language.boolean.ruby']
+    expect(tokens[26]).toEqual value: '|', scopes: ['source.ruby', 'punctuation.separator.variable.ruby']


### PR DESCRIPTION
Addresses issue arising from #113 where do blocks no longer worked as expected, which I tracked to commit 17c43c0029c60edc3eced9675451293d819caba3. When adding support for including `||` statements within do block variable definitions, as in:
```ruby
 do |a = b||c |   # Still formats funny in GitHub, but not in Atom due to this change
```
However, the end regex I used appeared to be messing up the surrounding areas, making them format funny. I changed the "end" match to be a positive lookahead and lookbehind rather than the simpler regex that included the surrounding characters in the match. This seems to retain the right behavior above while avoiding the issues brought up in #113.