### PR TITLE
Add rough support for YARD directives and three missing tags

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -2364,10 +2364,13 @@
       {
         'include': '#yard_types'
       }
+      {
+        'include': '#yard_directive'
+      }
     ]
   'yard_comment':
     'comment': 'For YARD tags that follow the tag-comment pattern'
-    'match': '(@)(abstract|api|author|deprecated|example|note|since|todo|version)(?=\\s)(.*)$'
+    'match': '(@)(abstract|api|author|deprecated|example|note|overload|since|todo|version)(?=\\s)(.*)$'
     'captures':
       '1':
         'name': 'comment.line.keyword.punctuation.yard.ruby'
@@ -2377,7 +2380,7 @@
         'name': 'comment.line.string.yard.ruby'
   'yard_name_types':
     'comment': 'For YARD tags that follow the tag-name-types-comment pattern'
-    'match': '(@)(attr|attr_reader|attr_writer|param|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(\\])))?(.*)$'
+    'match': '(@)(attr|attr_reader|attr_writer|option|param|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(\\])))?(.*)$'
     'captures':
       '1':
         'name': 'comment.line.keyword.punctuation.yard.ruby'
@@ -2407,7 +2410,25 @@
         'name': 'comment.line.keyword.yard.ruby'
   'yard_types':
     'comment': 'For YARD tags that follow the tag-types-comment pattern'
-    'match': '(@)(raise|return|yieldreturn)(?=\\s)(\\s+((\\[).+(\\])))?(.*)$'
+    'match': '(@)(raise|return|yield|yieldreturn)(?=\\s)(\\s+((\\[).+(\\])))?(.*)$'
+    'captures':
+      '1':
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
+      '2':
+        'name': 'comment.line.keyword.yard.ruby'
+      '3':
+        'name': 'comment.line.yard.ruby'
+      '4':
+        'name': 'comment.line.type.yard.ruby'
+      '5':
+        'name': 'comment.line.punctuation.yard.ruby'
+      '6':
+        'name': 'comment.line.punctuation.yard.ruby'
+      '7':
+        'name': 'comment.line.string.yard.ruby'
+  'yard_directive':
+    'comment': 'For YARD directives'
+    'match': '(@!)(attribute|endgroup|group|macro|method|parse|scope|visibility)(\\s+((\\[).+(\\])))?(?=\\s)(.*)$'
     'captures':
       '1':
         'name': 'comment.line.keyword.punctuation.yard.ruby'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -2410,7 +2410,7 @@
         'name': 'comment.line.keyword.yard.ruby'
   'yard_types':
     'comment': 'For YARD tags that follow the tag-types-comment pattern'
-    'match': '(@)(raise|return|yield|yieldreturn)(?=\\s)(\\s+((\\[).+(\\])))?(.*)$'
+    'match': '(@)(raise|return|yield(?:return)?)(?=\\s)(\\s+((\\[).+(\\])))?(.*)$'
     'captures':
       '1':
         'name': 'comment.line.keyword.punctuation.yard.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -510,7 +510,6 @@ describe "Ruby grammar", ->
     expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
     expect(tokens[8]).toEqual value: ' Baz', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
-
     {tokens} = grammar.tokenizeLine('# @return [Array#[](0), Array] comment')
     expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
     expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
@@ -532,6 +531,17 @@ describe "Ruby grammar", ->
     expect(tokens[6]).toEqual value: 'Array#[](0), Array', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
     expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
     expect(tokens[8]).toEqual value: ' comment', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+
+    {tokens} = grammar.tokenizeLine('# @!attribute [r] foo comment')
+    expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
+    expect(tokens[2]).toEqual value: '@!', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
+    expect(tokens[3]).toEqual value: 'attribute', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
+    expect(tokens[5]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[6]).toEqual value: 'r', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
+    expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[8]).toEqual value: ' foo comment', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
   it "tokenizes a method with *args properly", ->
     {tokens} = grammar.tokenizeLine('def method(*args)')


### PR DESCRIPTION
This request is to update YARD support by including highlighting for directives and the tags "option", "overload" and "yield". None of these are perfectly matched by the updated grammar (which would have to be fairly complex otherwise), but it's still a significant improvement.