### PR TITLE
Added arb to fileTypes for ruby grammar

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -3,6 +3,7 @@
 'fileTypes': [
   'Appfile'
   'Appraisals'
+  'arb'
   'Berksfile'
   'cap'
   'Capfile'


### PR DESCRIPTION
`.arb` is the extension used by arbre templates. arbre is used to generate HTML in Ruby.

Repo for arbre: https://github.com/activeadmin/arbre