### PR TITLE
Adds cr (Crystal lang) to fileTypes for Ruby grammar

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -9,6 +9,7 @@
   'Capfile'
   'capfile'
   'cgi'
+  'cr'
   'Deliverfile'
   'Fastfile'
   'fcgi'


### PR DESCRIPTION
[Crystal](http://crystal-lang.org/) has a Ruby-inspired syntax.