### PR TITLE
Fixes for tokenization of Kernel methods ending in ? or !

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -121,7 +121,7 @@
   }
   {
     'comment': ' just as above but being not a logical operation'
-    'match': '(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\\b(?![?!])|\\bdefined\\?|\\bblock_given\\?'
+    'match': '(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\\b(?![?!])|\\bdefined\\?|\\b(block_given|iterator)\\?'
     'name': 'keyword.control.pseudo-method.ruby'
   }
   {
@@ -204,7 +204,7 @@
     'name': 'support.class.ruby'
   }
   {
-    'match': '\\b(abort|at_exit|autoload\\??|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|exit!|fork|format|gets|global_variables|gsub|iterator\\?|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])'
+    'match': '\\b(abort|at_exit|autoload\\??|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|exit!|fork|format|gets|global_variables|gsub|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])'
     'name': 'support.function.kernel.ruby'
   }
   {

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -204,7 +204,7 @@
     'name': 'support.class.ruby'
   }
   {
-    'match': '\\b(abort|at_exit|autoload\\??|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|exit!|fork|format|gets|global_variables|gsub|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])'
+    'match': '\\b((abort|at_exit|autoload|binding|callcc|caller|caller_locations|chomp|chop|eval|exec|exit|fork|format|gets|global_variables|gsub|lambda|load|local_variables|open|p|print|printf|proc|putc|puts|rand|readline|readlines|select|set_trace_func|sleep|spawn|sprintf|srand|sub|syscall|system|test|trace_var|trap|untrace_var|warn)\\b(?![?!])|autoload\\?|exit!)'
     'name': 'support.function.kernel.ruby'
   }
   {

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -667,3 +667,14 @@ describe "Ruby grammar", ->
     lines = grammar.tokenizeLines('<<~EOS\nThis is text\nEOS')
     expect(lines[0][0]).toEqual value: '<<~EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
     expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
+
+  it "tokenizes Kernel support functions autoload? and exit!", ->
+    lines = grammar.tokenizeLines('p autoload?(:test)\nexit!')
+    expect(lines[0][2]).toEqual value: 'autoload?', scopes: ['source.ruby', 'support.function.kernel.ruby']
+    expect(lines[1][0]).toEqual value: 'exit!', scopes: ['source.ruby', 'support.function.kernel.ruby']
+
+  it "tokenizes iterator? the same way as block_given?", ->
+    lines = grammar.tokenizeLines('p iterator?\np block_given?')
+    expect(lines[0][2].value).toEqual 'iterator?'
+    expect(lines[1][2].value).toEqual 'block_given?'
+    expect(lines[0][2].scopes).toEqual lines[1][2].scopes

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -669,9 +669,10 @@ describe "Ruby grammar", ->
     expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
 
   it "tokenizes Kernel support functions autoload? and exit!", ->
-    lines = grammar.tokenizeLines('p autoload?(:test)\nexit!')
+    lines = grammar.tokenizeLines('p autoload?(:test)\nexit!\nat_exit!')
     expect(lines[0][2]).toEqual value: 'autoload?', scopes: ['source.ruby', 'support.function.kernel.ruby']
     expect(lines[1][0]).toEqual value: 'exit!', scopes: ['source.ruby', 'support.function.kernel.ruby']
+    expect(lines[2][0]).toEqual value: 'at_exit!', scopes: ['source.ruby']
 
   it "tokenizes iterator? the same way as block_given?", ->
     lines = grammar.tokenizeLines('p iterator?\np block_given?')


### PR DESCRIPTION
This is a bug fix for some Kernel methods ending with a ? or ! not being tokenized. Plus, ```iterator?``` is synonymous with ```block_given?``` (although "mildly deprecated" according to Ruby docs) so I included a test to ensure that they have the same scope, disregarding whatever that scope is in case it changes in the future.

For the sake of clarity, I added the tests and fixes as separate commits instead of squashing. Let me know if that's considered a good practice.