### PR TITLE
Changes dop and do order priority

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -12,6 +12,9 @@
   'if … end':
     'prefix': 'if'
     'body': 'if ${1:condition}\n\t$0\nend'
+  'it … end':
+    'prefix': 'it'
+    'body': 'it "${1:text}" do\n\t$0\nend'
   'case … end':
     'prefix': 'case'
     'body': 'case ${1:object}\nwhen ${2:condition}\n\t$0\nend'
@@ -150,12 +153,12 @@
   'directory()':
     'prefix': 'dir'
     'body': 'File.dirname(__FILE__)'
-  'Insert do … end':
-    'prefix': 'do'
-    'body': 'do\n\t$0\nend'
   'Insert do |variable| … end':
     'prefix': 'dop'
     'body': 'do |${1:variable}|\n\t$0\nend'
+  'Insert do … end':
+    'prefix': 'do'
+    'body': 'do\n\t$0\nend'
   'each { |e| .. }':
     'prefix': 'ea'
     'body': 'each { |${1:e}| $0 }'


### PR DESCRIPTION

![screen shot 2016-02-17 at 11 25 58](https://cloud.githubusercontent.com/assets/136777/13108295/0d8ade76-d56a-11e5-8060-dbf82d9ce8a9.png)

- When I type `do` I mean to have a block without any parameter

What is happening is that every time I type `do` it gives `dop` as first
option, that feels wrong, this commit aims to solve that problem by
changing the order.

- I've also added a new snippet for `it` blocks