### PR TITLE
Revert do/dop order change

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -153,12 +153,12 @@
   'directory()':
     'prefix': 'dir'
     'body': 'File.dirname(__FILE__)'
-  'Insert do |variable| … end':
-    'prefix': 'dop'
-    'body': 'do |${1:variable}|\n\t$0\nend'
   'Insert do … end':
     'prefix': 'do'
     'body': 'do\n\t$0\nend'
+  'Insert do |variable| … end':
+    'prefix': 'dop'
+    'body': 'do |${1:variable}|\n\t$0\nend'
   'each { |e| .. }':
     'prefix': 'ea'
     'body': 'each { |${1:e}| $0 }'


### PR DESCRIPTION
The broken behavior has already been fixed in the 1.6 betas.