### PR TITLE
Use Ruby 1.9 hash syntax for hash pair snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -210,9 +210,9 @@
   'grep(/pattern/) { |match| .. }':
     'prefix': 'gre'
     'body': 'grep(${1:/${2:pattern}/}) { |${3:match}| $0 }'
-  'Hash Pair — :key => "value"':
+  'Hash Pair — key: "value"':
     'prefix': 'hp'
-    'body': ':${1:key} => ${2:"${3:value}"}${4:, }'
+    'body': '${1:key}: ${2:"${3:value}"}${4:, }'
   'include Comparable ..':
     'prefix': 'Comp'
     'body': 'include Comparable\n\ndef <=>(other)\n\t$0\nend'


### PR DESCRIPTION
![2016-03-22 at 12 15 pm 1](https://cloud.githubusercontent.com/assets/2344137/13958929/5aec7340-f028-11e5-910c-d4f358e90951.png)

![2016-03-22 at 12 15 pm](https://cloud.githubusercontent.com/assets/2344137/13958935/5d9675d2-f028-11e5-8fb9-844be4d18cb1.png)

Any concerns for migrating to the Ruby 1.9 hash syntax?