### PR TITLE
Add Brewfile to fileTypes

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -5,6 +5,7 @@
   'Appraisals'
   'arb'
   'Berksfile'
+  'Brewfile'
   'cap'
   'Capfile'
   'capfile'


### PR DESCRIPTION
Brewfile files are used by https://github.com/homebrew/homebrew-bundle.