### PR TITLE
Recognize `source` keyword in grammar (for Gemfiles)

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -148,7 +148,7 @@
     'name': 'keyword.other.special-method.ruby'
   }
   {
-    'begin': '\\b(?<!\\.|::)(require|require_relative|gem)\\b(?![?!])'
+    'begin': '\\b(?<!\\.|::)(require|require_relative|gem|source)\\b(?![?!])'
     'captures':
       '1':
         'name': 'keyword.other.special-method.ruby'


### PR DESCRIPTION
Hi,

I recently starting learning about and working with Gemfiles in one of my projects. However, I noticed that while the language-ruby package nicely highlights the `gem` keyword in my file, it does not highlight the `source` keyword, which is (as far as I can tell) common to most Gemfiles ([see the first snippet on the Bundler homepage](http://bundler.io/gemfile.html))

![Gemfile in Atom](https://cloud.githubusercontent.com/assets/872474/16322846/0032adc6-395b-11e6-8780-c71989dfd9d5.png)

With my simple tweak to the grammar to fix this, all tests are still passing, though I didn't think it was necessary to add an additional unit test (and if so, then you might as well add unit tests for all of the other syntax-highlighted keywords).

Anyway, thanks for considering this. Let me know if there is anything more I can do.
Caleb