### PR TITLE
Remove redundancies in the grammar of percent literals

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1969,19 +1969,15 @@
   'interpolated_ruby':
     'patterns': [
       {
-        'begin': '(#{)'
+        'begin': '#{'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.ruby'
-          '1':
-            'name': 'source.ruby'
         'contentName': 'source.ruby'
-        'end': '(})'
+        'end': '}'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.ruby'
-          '1':
-            'name': 'source.ruby'
         'name': 'meta.embedded.line.ruby'
         'patterns': [
           {

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1055,7 +1055,7 @@
     ]
   }
   {
-    'begin': '%Q\\('
+    'begin': '%Q?\\('
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1078,7 +1078,7 @@
     ]
   }
   {
-    'begin': '%Q\\['
+    'begin': '%Q?\\['
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1101,30 +1101,7 @@
     ]
   }
   {
-    'begin': '%Q<'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and <> delimitor'
-    'end': '>'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_ltgt_i'
-      }
-    ]
-  }
-  {
-    'begin': '%Q{'
+    'begin': '%Q?{'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1147,6 +1124,29 @@
     ]
   }
   {
+    'begin': '%Q?<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'string literal with interpolation and <> delimitor'
+    'end': '>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.other.interpolated.ruby'
+    'patterns': [
+      {
+        'include': '#interpolated_ruby'
+      }
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#nest_ltgt_i'
+      }
+    ]
+  }
+  {
     'begin': '%Q([^\\w])'
     'beginCaptures':
       '0':
@@ -1163,94 +1163,6 @@
       }
       {
         'include': '#escaped_char'
-      }
-    ]
-  }
-  {
-    'begin': '%{'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'end': '}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_curly'
-      }
-    ]
-  }
-  {
-    'begin': '%\\['
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'end': ']'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_brackets'
-      }
-    ]
-  }
-  {
-    'begin': '%\\('
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_parens'
-      }
-    ]
-  }
-  {
-    'begin': '%<'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'end': '>'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.quoted.other.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_ltgt'
       }
     ]
   }

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -422,7 +422,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.regexp.begin.ruby'
-    'comment': 'regular expression literal with interpolation and {} delimitor'
     'end': '}[eimnosux]*'
     'endCaptures':
       '0':
@@ -442,7 +441,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.regexp.begin.ruby'
-    'comment': 'regular expression literal with interpolation and [] delimitor'
     'end': '][eimnosux]*'
     'endCaptures':
       '0':
@@ -462,7 +460,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.regexp.begin.ruby'
-    'comment': 'regular expression literal with interpolation and () delimitor'
     'end': '\\)[eimnosux]*'
     'endCaptures':
       '0':
@@ -482,7 +479,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.regexp.begin.ruby'
-    'comment': 'regular expression literal with interpolation and <> delimitor'
     'end': '>[eimnosux]*'
     'endCaptures':
       '0':
@@ -502,7 +498,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.regexp.begin.ruby'
-    'comment': 'regular expression literal with interpolation and {} delimitor'
     'end': '\\1[eimnosux]*'
     'endCaptures':
       '0':
@@ -519,7 +514,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with interpolation and [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -542,7 +536,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with interpolation and () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -565,7 +558,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with interpolation and <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -588,7 +580,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with interpolation and {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -611,7 +602,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -631,7 +621,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -652,7 +641,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -673,7 +661,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -694,7 +681,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -715,7 +701,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of symbols literal with wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -733,7 +718,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with interpolation and [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -756,7 +740,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with interpolation and () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -779,7 +762,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with interpolation and <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -802,7 +784,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with interpolation and {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -825,7 +806,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -845,7 +825,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -866,7 +845,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -887,7 +865,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -908,7 +885,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -929,7 +905,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.array.begin.ruby'
-    'comment': 'array of strings literal with wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -947,7 +922,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -970,7 +944,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -993,7 +966,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -1016,7 +988,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -1039,7 +1010,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -1059,7 +1029,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -1079,7 +1048,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -1100,7 +1068,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -1121,7 +1088,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -1142,7 +1108,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -1163,7 +1128,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':
@@ -1181,7 +1145,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': 'symbol literal with () delimitor'
     'end': '\\)'
     'endCaptures':
       '0':
@@ -1202,7 +1165,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': 'symbol literal with <> delimitor'
     'end': '>'
     'endCaptures':
       '0':
@@ -1223,7 +1185,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': 'symbol literal with [] delimitor'
     'end': ']'
     'endCaptures':
       '0':
@@ -1244,7 +1205,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': 'symbol literal with {} delimitor'
     'end': '}'
     'endCaptures':
       '0':
@@ -1265,7 +1225,6 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': 'symbol literal with wildcard delimitor'
     'end': '\\1'
     'endCaptures':
       '0':

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -402,118 +402,6 @@
     ]
   }
   {
-    'begin': '%x{'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'execute string (allow for interpolation)'
-    'end': '}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_curly_i'
-      }
-    ]
-  }
-  {
-    'begin': '%x\\['
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'execute string (allow for interpolation)'
-    'end': ']'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_brackets_i'
-      }
-    ]
-  }
-  {
-    'begin': '%x<'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'execute string (allow for interpolation)'
-    'end': '>'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_ltgt_i'
-      }
-    ]
-  }
-  {
-    'begin': '%x\\('
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'execute string (allow for interpolation)'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#nest_parens_i'
-      }
-    ]
-  }
-  {
-    'begin': '%x([^\\w])'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'execute string (allow for interpolation)'
-    'end': '\\1'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.ruby'
-    'name': 'string.interpolated.ruby'
-    'patterns': [
-      {
-        'include': '#interpolated_ruby'
-      }
-      {
-        'include': '#escaped_char'
-      }
-    ]
-  }
-  {
     'begin': '(?<![\\w)])((/))(?![*+?])(?=(?:\\\\/|[^/])*/[eimnosux]*\\s*([\\]#).,?:}]|$|\\|\\||&&|<=>|=>|==|=~|!~|!=|;|if|else|elsif|then|do|end|unless|while|until|or|and))'
     'captures':
       '1':
@@ -1055,7 +943,7 @@
     ]
   }
   {
-    'begin': '%Q?\\('
+    'begin': '%[Qx]?\\('
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1078,7 +966,7 @@
     ]
   }
   {
-    'begin': '%Q?\\['
+    'begin': '%[Qx]?\\['
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1101,7 +989,7 @@
     ]
   }
   {
-    'begin': '%Q?{'
+    'begin': '%[Qx]?{'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1124,7 +1012,7 @@
     ]
   }
   {
-    'begin': '%Q?<'
+    'begin': '%[Qx]?<'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
@@ -1147,7 +1035,7 @@
     ]
   }
   {
-    'begin': '%Q([^\\w])'
+    'begin': '%[Qx]([^\\w])'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -96,17 +96,6 @@ describe "Ruby grammar", ->
     expect(tokens[2]).toEqual value: ' ', scopes: ['source.ruby']
     expect(tokens[3]).toEqual value: 'read ', scopes: ['source.ruby']
 
-  it "tokenizes %{} style strings", ->
-    {tokens} = grammar.tokenizeLine('%{te{s}t}')
-
-    expect(tokens[0]).toEqual value: '%{', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
-    expect(tokens[1]).toEqual value: 'te', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
-    expect(tokens[2]).toEqual value: '{', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
-    expect(tokens[3]).toEqual value: 's', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
-    expect(tokens[4]).toEqual value: '}', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
-    expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
-    expect(tokens[6]).toEqual value: '}', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
-
   it "tokenizes %() style strings", ->
     {tokens} = grammar.tokenizeLine('%(te(s)t)')
 
@@ -129,6 +118,17 @@ describe "Ruby grammar", ->
     expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
     expect(tokens[6]).toEqual value: ']', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
 
+  it "tokenizes %{} style strings", ->
+    {tokens} = grammar.tokenizeLine('%{te{s}t}')
+
+    expect(tokens[0]).toEqual value: '%{', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: 'te', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '{', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
+    expect(tokens[3]).toEqual value: 's', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[4]).toEqual value: '}', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
+    expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[6]).toEqual value: '}', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
+
   it "tokenizes %<> style strings", ->
     {tokens} = grammar.tokenizeLine('%<te<s>t>')
 
@@ -139,6 +139,17 @@ describe "Ruby grammar", ->
     expect(tokens[4]).toEqual value: '>', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
     expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
     expect(tokens[6]).toEqual value: '>', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
+
+  it "tokenizes %Q() style strings", ->
+    {tokens} = grammar.tokenizeLine('%Q(te(s)t)')
+
+    expect(tokens[0]).toEqual value: '%Q(', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: 'te', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '(', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
+    expect(tokens[3]).toEqual value: 's', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[4]).toEqual value: ')', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.section.scope.ruby']
+    expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[6]).toEqual value: ')', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
 
   it "tokenizes regular expressions", ->
     {tokens} = grammar.tokenizeLine('/test/')

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -162,6 +162,14 @@ describe "Ruby grammar", ->
     expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
     expect(tokens[6]).toEqual value: ')', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
 
+  it "tokenizes %x!! style strings", ->
+    {tokens} = grammar.tokenizeLine('%x!\#\{"l" + "s"\}!')
+
+    expect(tokens[0]).toEqual value: '%x!', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: '#{', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'meta.embedded.line.ruby', 'punctuation.section.embedded.begin.ruby']
+    expect(tokens[11]).toEqual value: '}', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'meta.embedded.line.ruby', 'punctuation.section.embedded.end.ruby']
+    expect(tokens[12]).toEqual value: '!', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
+
   it "tokenizes regular expressions", ->
     {tokens} = grammar.tokenizeLine('/test/')
 

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -140,6 +140,17 @@ describe "Ruby grammar", ->
     expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
     expect(tokens[6]).toEqual value: '>', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
 
+  it "tokenizes %~~ style strings", ->
+    {tokens} = grammar.tokenizeLine('%~te\\~s\\~t~')
+
+    expect(tokens[0]).toEqual value: '%~', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: 'te', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '\\~', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'constant.character.escape.ruby']
+    expect(tokens[3]).toEqual value: 's', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[4]).toEqual value: '\\~', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'constant.character.escape.ruby']
+    expect(tokens[5]).toEqual value: 't', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby']
+    expect(tokens[6]).toEqual value: '~', scopes: ['source.ruby', 'string.quoted.other.interpolated.ruby', 'punctuation.definition.string.end.ruby']
+
   it "tokenizes %Q() style strings", ->
     {tokens} = grammar.tokenizeLine('%Q(te(s)t)')
 


### PR DESCRIPTION
It's shocking to see nearly half of the grammar is devoted to % literals :joy: which is a fairly small part of Ruby.

* `%` is the shorthand of `%Q`—they're the same thing (when `%` used to denote a string).
* `%Q` and `%x` both return a string, and allow interpolation and escaped characters.
* The comments are just stating the obvious—what does the literal do—bascially just noise.

