### PR TITLE
Drop a rails snippet `classify` from Ruby language

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -114,9 +114,6 @@
   'class_from_name()':
     'prefix': 'clafn'
     'body': 'split("::").inject(Object) { |par, const| par.const_get(const) }'
-  'classify { |e| .. }':
-    'prefix': 'cl'
-    'body': 'classify { |${1:e}| $0 }'
   'collect { |e| .. }':
     'prefix': 'col'
     'body': 'collect { |${1:e}| $0 }'


### PR DESCRIPTION
With rails
```shell
$  ruby --version && rails --version && rails runner 'p "st_ring".classify'
```
```
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
Rails 4.1.14
Running via Spring preloader in process 17782
"StRing"
```

Just ruby
```shell
$  ruby --version && ruby -e 'p "st_ring".classify'
```
```
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
-e:1:in `<main>': undefined method `classify' for "st_ring":String (NoMethodError)
Did you mean?  class
```

May I move this into https://github.com/atom/language-ruby-on-rails ?