### PR TITLE
Extend recognition of modelines and hashbangs

### DIFF
--- a/grammars/html (ruby - erb).cson
+++ b/grammars/html (ruby - erb).cson
@@ -1,3 +1,5 @@
+'name': 'HTML (Ruby - ERB)'
+'scopeName': 'text.html.erb'
 'fileTypes': [
   'erb'
   'rhtml'
@@ -43,7 +45,6 @@
         'include': '#tags'
       }
     ]
-'name': 'HTML (Ruby - ERB)'
 'patterns': [
   {
     'include': 'text.html.basic'
@@ -119,4 +120,3 @@
         ]
       }
     ]
-'scopeName': 'text.html.erb'

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -40,7 +40,25 @@
   'Thorfile'
   'Vagrantfile'
 ]
-'firstLineMatch': '^#!\\s*/.*\\bruby|^#\\s+-\\*-\\s*ruby\\s*-\\*-'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    (?:ruby|macruby|rake|jruby|rbx)
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      ruby
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      ruby
+    (?=\\s|:|$)
+  )
+'''
 'patterns': [
   {
     'captures':


### PR DESCRIPTION
Usual affair. List of interpreters taken from Linguist's [language database](https://github.com/github/linguist/blob/67ed060d378f7e39992c0f520bbb4a408f2f5f81/lib/linguist/languages.yml#L3627-L3632). Note I couldn't find any ERB modes that Vim or Emacs recognised, so I left that grammar alone.