### PR TITLE
grammer fix for leading underscore in constants, resolves #178

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -240,7 +240,7 @@
     'name': 'support.function.kernel.ruby'
   }
   {
-    'match': '\\b[A-Z]\\w*\\b'
+    'match': '\\b[_A-Z]\\w*\\b'
     'name': 'variable.other.constant.ruby'
   }
   {

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -32,6 +32,13 @@ describe "Ruby grammar", ->
     expect(tokens[1]).toEqual value: '&.', scopes: ['source.ruby', 'punctuation.separator.method.ruby']
     expect(tokens[2]).toEqual value: 'call', scopes: ['source.ruby']
 
+  it "tokenizes variable constants", ->
+    {tokens} = grammar.tokenizeLine('VAR1 = 100')
+    expect(tokens[0]).toEqual value: 'VAR1', scopes: ['source.ruby', 'variable.other.constant.ruby']
+
+    {tokens} = grammar.tokenizeLine('_VAR2 = 200')
+    expect(tokens[0]).toEqual value: '_VAR2', scopes: ['source.ruby', 'variable.other.constant.ruby']
+
   it "tokenizes decimal numbers", ->
     {tokens} = grammar.tokenizeLine('100_000')
     expect(tokens[0]).toEqual value: '100_000', scopes: ['source.ruby', 'constant.numeric.ruby']


### PR DESCRIPTION
![constant](https://cloud.githubusercontent.com/assets/4008169/20798272/4dcc7dda-b7ac-11e6-93fb-1d7dd99d18ef.gif)
resolves #178 