### PR TITLE
Stop treating .erb files as HTML

### DIFF
--- a/grammars/html (ruby - erb).cson
+++ b/grammars/html (ruby - erb).cson
@@ -1,7 +1,6 @@
 'name': 'HTML (Ruby - ERB)'
 'scopeName': 'text.html.erb'
 'fileTypes': [
-  'erb'
   'rhtml'
   'html.erb'
 ]


### PR DESCRIPTION
`.rhtml` files and `.html.erb` files are still considered to be HTML.

The rationale behind this change is that we use Puppet extensively where I work and have a ton of non-HTML `.erb` files. Every time I open one of them Atom starts doing HTML highlighting and linting on them.

While this change won't make Atom start doing the right thing here, it will at least stop Atom from doing the wrong thing.

This change is related to https://github.com/atom/language-ruby/issues/180.

Here's an example of how to add `.erb` support to other file formats: https://github.com/atom/language-yaml/blob/d63dffb62bc5eeb0681e8c886ec639cd80722563/grammars/yaml.cson#L9.