### PR TITLE
add `and`, `or` to control keywords regex

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1836,7 +1836,7 @@
     'name': 'keyword.operator.comparison.ruby'
   }
   {
-    'match': '(?<!\\.)\\b(and|not|or)\\b(?![?!])'
+    'match': '(?<!\\.)\\b(not)\\b(?![?!])'
     'name': 'keyword.operator.logical.ruby'
   }
   {

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -153,7 +153,7 @@
     'name': 'meta.syntax.ruby.start-block'
   }
   {
-    'match': '(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|undef|yield)\\b(?![?!])|\\bdefined\\?|\\b(block_given|iterator)\\?'
+    'match': '(?<!\\.)\\b(alias|alias_method|and|break|next|or|redo|retry|return|super|undef|yield)\\b(?![?!])|\\bdefined\\?|\\b(block_given|iterator)\\?'
     'name': 'keyword.control.pseudo-method.ruby'
   }
   {

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -456,7 +456,7 @@ describe "Ruby grammar", ->
     expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
     expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
-    expect(tokens[4]).toEqual value: 'or', scopes: ['source.ruby', 'keyword.operator.logical.ruby']
+    expect(tokens[4]).toEqual value: 'or', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
     expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
     expect(tokens[6]).toEqual value: 'return', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
 
@@ -466,7 +466,7 @@ describe "Ruby grammar", ->
     expect(tokens[1]).toEqual value: 'test', scopes: ['source.ruby', 'string.regexp.interpolated.ruby']
     expect(tokens[2]).toEqual value: '/', scopes: ['source.ruby', 'string.regexp.interpolated.ruby', 'punctuation.section.regexp.ruby']
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.ruby']
-    expect(tokens[4]).toEqual value: 'and', scopes: ['source.ruby', 'keyword.operator.logical.ruby']
+    expect(tokens[4]).toEqual value: 'and', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
     expect(tokens[5]).toEqual value: ' ', scopes: ['source.ruby']
     expect(tokens[6]).toEqual value: 'return', scopes: ['source.ruby', 'keyword.control.pseudo-method.ruby']
 


### PR DESCRIPTION
`and`, `or` are more useful as control flow keywords than logical operators due to their odd precedence. This idea is expressed really well by [episode 125 of Ruby Tapas](https://www.rubytapas.com/2013/08/15/episode-125-and-or/)