### PR TITLE
Minitest assertion snippets

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -81,18 +81,26 @@
   'application { .. }':
     'prefix': 'app'
     'body': 'if __FILE__ == \\$PROGRAM_NAME\n\t$0\nend'
-  'assert_nothing_raised(..) { .. }':
-    'prefix': 'asnr'
-    'body': 'assert_nothing_raised(${1:Exception}) { $0 }'
-  'assert_nothing_thrown { .. }':
-    'prefix': 'asnt'
-    'body': 'assert_nothing_thrown { $0 }'
-  'assert_raise(..) { .. }':
+  'assert':
+    'prefix': 'as'
+    'body': 'assert ${1:test}'
+    'leftLabel': 'minitest'
+    'description': 'Ensures that `test` is true'
+  'assert_empty':
+    'prefix': 'ase'
+    'body': 'assert_empty ${1:object}'
+    'leftLabel': 'minitest'
+    'description': 'Ensures that `object` is `empty?`'
+  'assert_raise':
     'prefix': 'asr'
     'body': 'assert_raise(${1:Exception}) { $0 }'
-  'assert_throws(..) { .. }':
+    'leftLabel': 'minitest'
+    'description': 'Ensures that the given block raises one of the given exceptions'
+  'assert_throws':
     'prefix': 'ast'
-    'body': 'assert_throws(:${1:expected}) { $0 }'
+    'body': 'assert_throws(:${1:symbol}) { $0 }'
+    'leftLabel': 'minitest'
+    'description': 'Ensures that the given block throws the `symbol`'
   'attr_accessor ..':
     'prefix': 'rw'
     'body': 'attr_accessor :${0:attr_names}'


### PR DESCRIPTION
I'd like to update snippets here and I want to start with `assert*` snippets.

This change can be backward incompatible (some prefixes may change, some snippets may be deleted) so before doing [21 snippets for minitest assertions](http://docs.seattlerb.org/minitest/Minitest/Assertions.html), I'd like to discuss here if this is needed.

 I want to use [autocomplete-plus API](https://github.com/atom/snippets#optional-parameters) for extra information about snippet so autocomplete view will be like this:
<img width="422" alt="screen shot 2017-01-10 at 9 51 40 pm" src="https://cloud.githubusercontent.com/assets/901000/21822547/4b291e64-d780-11e6-9ef5-04c5e2174dd3.png">
*Snippets without `minitest` label are from [language-ruby-on-rails](https://github.com/atom/language-ruby-on-rails), so similar work is required on that package.*

Here is list of all `assert*` methods I'd like to implement:
- [ ] `assert(test, msg = nil)`
- [ ] `assert_empty(obj, msg = nil)`
- [ ] `assert_equal(exp, act, msg = nil)`
- [ ] `assert_in_delta(exp, act, delta = 0.001, msg = nil)`
- [ ] `assert_in_epsilon(a, b, epsilon = 0.001, msg = nil)`
- [ ] `assert_includes(collection, obj, msg = nil)`
- [ ] `assert_instance_of(cls, obj, msg = nil)`
- [ ] `assert_kind_of(cls, obj, msg = nil)`
- [ ] `assert_match(matcher, obj, msg = nil)`
- [ ] `assert_mock(mock)`
- [ ] `assert_nil(obj, msg = nil)`
- [ ] `assert_operator(o1, op, o2 = UNDEFINED, msg = nil)`
- [ ] `assert_output(stdout = nil, stderr = nil) { || ... }`
- [ ] `assert_predicate(o1, op, msg = nil)`
- [ ] `assert_predicate str, :empty?`
- [ ] `assert_raises(*exp) { || ... }`
- [ ] `assert_respond_to(obj, meth, msg = nil)`
- [ ] `assert_same(exp, act, msg = nil)`
- [ ] `assert_send(send_ary, m = nil)`
- [ ] `assert_silent() { || ... }`
- [ ] `assert_throws(sym, msg = nil) { || ... }`
