### PR TITLE
Highlight embedded graphql

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1476,6 +1476,40 @@
     ]
   }
   {
+    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))'
+    'comment': 'Heredoc with embedded GraphQL'
+    'end': '(?!\\G)'
+    'name': 'meta.embedded.block.graphql'
+    'patterns': [
+      {
+        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.ruby'
+        'contentName': 'source.graphql'
+        'end': '\\s*\\2$\\n?'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.ruby'
+        'name': 'string.unquoted.heredoc.ruby'
+        'patterns': [
+          {
+            'include': '#heredoc'
+          }
+          {
+            'include': '#interpolated_ruby'
+          }
+          {
+            'include': 'source.graphql'
+          }
+          {
+            'include': '#escaped_char'
+          }
+        ]
+      }
+    ]
+  }
+  {
     'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)CSS)\\b\\1))'
     'comment': 'Heredoc with embedded css'
     'end': '(?!\\G)'


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2231765/21859764/f44763cc-d7fb-11e6-90c2-63c202501060.png)

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I recently discovered that language-ruby will highlight SQL inside `<<-SQL` heredoc blocks. Cool! 

I often use `<<-GRAPHQL` to write inline GraphQL queries, so I thought, maybe I can modify language-ruby to highlight GraphQL within those blocks. 

This PR adds GraphQL highlighting within `<<-GRAPHQL` heredoc blocks, as shown above.

### Alternate Designs

I didn't consider alternate designs, I just copied and modified one of the other heredoc highlighters. 

### Benefits

GraphQL users can have highlighted GraphQL inside their Ruby files.

### Possible Drawbacks

This introduces a maintenance burden: more lines of code means more things that can break 😬 

This heredoc highlighter is not tested. I didn't find tests for the others, either. Are there any? 

### Applicable Issues

Fixes #173 

Thanks for considering this change!

