### PR TITLE
Tokenize `group` keyword used in Gemfiles

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -178,7 +178,7 @@
     'name': 'keyword.other.special-method.ruby'
   }
   {
-    'begin': '\\b(?<!\\.|::)(require|require_relative|gem|source)\\b(?![?!])'
+    'begin': '\\b(?<!\\.|::)(group|require|require_relative|gem|source)\\b(?![?!])'
     'captures':
       '1':
         'name': 'keyword.other.special-method.ruby'


### PR DESCRIPTION
### Requirements

This PR is similar to my addition in #149, which added tokenization for `source`, a Ruby keyword used specifically in Gemfiles. This time, I'm adding tokenization for the `group` keyword, also used in Gemfiles (and especially common in Jekyll site Gemfiles for identifying Jekyll-specific plugins)

As in #149, I don't think a unit test for this single keyword addition is really needed, but all existing tests are still passing, and if you'd really prefer, I can surely add one. :)

### Description of the Change

**Before:**  
<img width="421" alt="screen shot 2017-01-16 at 9 47 22 pm" src="https://cloud.githubusercontent.com/assets/872474/22009190/3254420a-dc36-11e6-898e-cb35a7950aa0.png">

**After:**  
<img width="413" alt="screen shot 2017-01-16 at 9 47 44 pm" src="https://cloud.githubusercontent.com/assets/872474/22009193/352077ba-dc36-11e6-9b09-487c272c9323.png">

### Alternate Designs

N/A

### Benefits

More highlighting!

### Possible Drawbacks

None!

### Applicable Issues

None!
