### PR TITLE
Tokenize `ruby` keyword used in Gemfiles

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -178,7 +178,7 @@
     'name': 'keyword.other.special-method.ruby'
   }
   {
-    'begin': '\\b(?<!\\.|::)(group|require|require_relative|gem|source)\\b(?![?!])'
+    'begin': '\\b(?<!\\.|::)(group|require|require_relative|gem|ruby|source)\\b(?![?!])'
     'captures':
       '1':
         'name': 'keyword.other.special-method.ruby'


### PR DESCRIPTION
This PR tokenizes the `ruby` keyword used to declare the Ruby version in Gemfiles—pretty much the same as #149 and #188, which have both been merged in.

**Before:**  
![screen shot 2017-01-17 at 10 06 43 am](https://cloud.githubusercontent.com/assets/872474/22033342/064f2938-dc9d-11e6-90a5-6978e369b42b.png)

**After:**  
![screen shot 2017-01-17 at 10 07 02 am](https://cloud.githubusercontent.com/assets/872474/22033352/0dbe01f8-dc9d-11e6-8456-a11435198d0a.png)

...because, I mean, who doesn't like syntax highlighting for everything? :D