### PR TITLE
make 'it' snippets use single quotes by default

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -14,7 +14,7 @@
     'body': 'if ${1:condition}\n\t$0\nend'
   'it … end':
     'prefix': 'it'
-    'body': 'it "${1:text}" do\n\t$0\nend'
+    'body': 'it \'${1:text}\' do\n\t$0\nend'
   'case … end':
     'prefix': 'case'
     'body': 'case ${1:object}\nwhen ${2:condition}\n\t$0\nend'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This change makes it so that when using the `it` snippet, the text in the it block is surrounded by single quotes rather than double quotes. Thus when typing `it` in the editor, where previously you'd have gotten 

```Ruby
it "does the thing" do
  Thing.do
end

# => spec/models/custom_event_spec.rb:144:7: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
      "does the thing"
      ^^^^^^^^^^^^^^^^
```

### Alternate Designs

Not doing this. Rubocop allows double quotes when the text inside them contains a single quote, escape codes, or string interpolation. My experience is that `it` block descriptions generally don't contain these things, however

### Benefits

<!-- What benefits will be realized by the code change? -->
 It will be less work for developers to change quote types

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
When escape codes or interpolation are necessary, the inciting issue of this PR will present itself in reverse - 'I wanted double quotes but I got single quotes'

### Applicable Issues

<!-- Enter any applicable Issues here -->
