### PR TITLE
Add separate grammar file for Gemfiles

### DIFF
--- a/grammars/gemfile.cson
+++ b/grammars/gemfile.cson
@@ -1,0 +1,23 @@
+'name': 'Gemfile'
+'scopeName': 'source.ruby.gemfile'
+'fileTypes': [
+  'Gemfile'
+]
+'patterns': [
+  {
+    'include': 'source.ruby'
+  }
+  {
+    'begin': '\\b(?<!\\.|::)(gem|git|group|platforms|ruby|source)\\b(?![?!])'
+    'captures':
+     '1':
+       'name': 'keyword.other.special-method.ruby.gemfile'
+    'end': '$|(?=#|})'
+    'name': 'meta.declaration.ruby.gemfile'
+    'patterns': [
+      {
+       'include': '$self'
+      }
+    ]
+  }
+]

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -15,7 +15,6 @@
   'Deliverfile'
   'Fastfile'
   'fcgi'
-  'Gemfile'
   'gemspec'
   'Guardfile'
   'irbrc'
@@ -178,7 +177,7 @@
     'name': 'keyword.other.special-method.ruby'
   }
   {
-    'begin': '\\b(?<!\\.|::)(group|require|require_relative|gem|ruby|source)\\b(?![?!])'
+    'begin': '\\b(?<!\\.|::)(require|require_relative)\\b(?![?!])'
     'captures':
       '1':
         'name': 'keyword.other.special-method.ruby'

--- a/spec/gemfile-spec.coffee
+++ b/spec/gemfile-spec.coffee
@@ -44,3 +44,11 @@ describe "Gemfile grammar", ->
     {tokens} = grammar.tokenizeLine(':foo')
     expect(tokens[0]).toEqual value: ':', scopes: ['source.ruby.gemfile', 'constant.other.symbol.ruby', 'punctuation.definition.constant.ruby']
     expect(tokens[1]).toEqual value: 'foo', scopes: ['source.ruby.gemfile', 'constant.other.symbol.ruby']
+
+  it "tokenizes group properly in ruby code", ->
+    {tokens} = grammar.tokenizeLine('do |group|')
+    expect(tokens[0]).toEqual value: 'do', scopes: ['source.ruby.gemfile', 'keyword.control.start-block.ruby']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby.gemfile']
+    expect(tokens[2]).toEqual value: '|', scopes: ['source.ruby.gemfile', 'punctuation.separator.variable.ruby']
+    expect(tokens[3]).toEqual value: 'group', scopes: ['source.ruby.gemfile', 'variable.other.block.ruby']
+    expect(tokens[4]).toEqual value: '|', scopes: ['source.ruby.gemfile', 'punctuation.separator.variable.ruby']

--- a/spec/gemfile-spec.coffee
+++ b/spec/gemfile-spec.coffee
@@ -1,0 +1,46 @@
+describe "Gemfile grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-ruby")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.ruby.gemfile")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe "source.ruby.gemfile"
+
+  it "tokenizes ruby", ->
+    {tokens} = grammar.tokenizeLine('ruby')
+    expect(tokens[0]).toEqual value: 'ruby', scopes: ['source.ruby.gemfile', 'meta.declaration.ruby.gemfile', 'keyword.other.special-method.ruby.gemfile']
+
+  it "tokenizes source", ->
+    {tokens} = grammar.tokenizeLine('source')
+    expect(tokens[0]).toEqual value: 'source', scopes: ['source.ruby.gemfile', 'meta.declaration.ruby.gemfile', 'keyword.other.special-method.ruby.gemfile']
+
+  it "tokenizes group", ->
+    {tokens} = grammar.tokenizeLine('group')
+    expect(tokens[0]).toEqual value: 'group', scopes: ['source.ruby.gemfile', 'meta.declaration.ruby.gemfile', 'keyword.other.special-method.ruby.gemfile']
+
+  it "tokenizes gem", ->
+    {tokens} = grammar.tokenizeLine('gem')
+    expect(tokens[0]).toEqual value: 'gem', scopes: ['source.ruby.gemfile', 'meta.declaration.ruby.gemfile', 'keyword.other.special-method.ruby.gemfile']
+
+  it "tokenizes double-quoted strings", ->
+    {tokens} = grammar.tokenizeLine('"foo"')
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.ruby.gemfile', 'string.quoted.double.interpolated.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: 'foo', scopes: ['source.ruby.gemfile', 'string.quoted.double.interpolated.ruby']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.ruby.gemfile', 'string.quoted.double.interpolated.ruby', 'punctuation.definition.string.end.ruby']
+
+  it "tokenizes single-quoted strings", ->
+    {tokens} = grammar.tokenizeLine('\'foo\'')
+    expect(tokens[0]).toEqual value: '\'', scopes: ['source.ruby.gemfile', 'string.quoted.single.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(tokens[1]).toEqual value: 'foo', scopes: ['source.ruby.gemfile', 'string.quoted.single.ruby']
+    expect(tokens[2]).toEqual value: '\'', scopes: ['source.ruby.gemfile', 'string.quoted.single.ruby', 'punctuation.definition.string.end.ruby']
+
+  it "tokenizes group names", ->
+    {tokens} = grammar.tokenizeLine(':foo')
+    expect(tokens[0]).toEqual value: ':', scopes: ['source.ruby.gemfile', 'constant.other.symbol.ruby', 'punctuation.definition.constant.ruby']
+    expect(tokens[1]).toEqual value: 'foo', scopes: ['source.ruby.gemfile', 'constant.other.symbol.ruby']


### PR DESCRIPTION
### Description of the Change

This PR adds a separate grammar file for tokenizing Gemfiles. It is ultimately the result of #195, which came about because my attempt to tokenize the Gemfile `group` keyword in https://github.com/atom/language-ruby/commit/54db19f1c9a09264e61f3fddec0b09e768f5c8e0 actually broke highlighting in Ruby files where `group` was used as a variable name.

That bug reflects a larger problem in that, while [Gemfiles are evaluated as Ruby code](http://bundler.io/v1.0/man/gemfile.5.html#SYNTAX), Gemfiles have access to several methods (like `gem`) which should arguably be highlighted in Gemfiles but *not* in any other Ruby context.

<img width="417" alt="after" src="https://cloud.githubusercontent.com/assets/872474/24067740/d2cc6088-0b3d-11e7-806e-cabb486a1bb7.png">

A corresponding spec accompanies the new grammar because automated testing is a wonderful thing.

### Alternate Designs

Removing syntax highlighting for these keywords was first considered, though (as I understand it) the Atom convention is to opt for more syntax highlighting (where appropriate) rather than less. Also, because Gemfiles can contain any arbitrary Ruby code (and often contain `"strings"` and `:constants` and such), the new grammar inherits all rules from `ruby.cson` via grammar `include`.

### Benefits

More syntax highlighting that shouldn't break anything this time!

### Possible Drawbacks

I suppose having to maintain a separate grammar file could be considered a drawback, though the grammar is quite small (especially with the `include` in place), making the maintenance overhead pretty minimal IMHO.

### Applicable Issues

#195, as mentioned above.