### PR TITLE
Add `ruby_executable_hooks` to hashbang recognition

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -42,7 +42,7 @@
 'firstLineMatch': '''(?x)
   # Hashbang
   ^\\#!.*(?:\\s|\\/)
-    (?:ruby|macruby|rake|jruby|rbx)
+    (?:ruby|macruby|rake|jruby|rbx|ruby_executable_hooks)
   (?:$|\\s)
   |
   # Modeline

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -788,6 +788,7 @@ describe "Ruby grammar", ->
         #!/usr/bin/macruby bin/perl
         #!/usr/bin/rbx
         #!/bin/rbx
+        #!/bin/env ruby_executable_hooks
         #!/usr/bin/ruby --script=usr/bin
         #! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail rbx
         #!\t/usr/bin/env --foo=bar ruby --quu=quux


### PR DESCRIPTION
### Description of the Change

This PR simply adds the name of another executable to the grammar's hashbang-recognition pattern.

The executables generated by RubyGems use this as their first line:

~~~ruby
#!/usr/bin/env ruby_executable_hooks
~~~

Since the files have no extension, there's nothing to activate the grammar:
<img width="197" alt="screen shot 2017-04-28 at 11 31 37 pm" src="https://cloud.githubusercontent.com/assets/2346707/25530783/dac6c0f0-2c6a-11e7-87fb-fb67896ea3ea.png">



