### PR TITLE
Highlighting embedded XML in HEREDOC block

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1441,6 +1441,40 @@
     ]
   }
   {
+    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)XML)\\b\\1))'
+    'comment': 'Heredoc with embedded xml'
+    'end': '(?!\\G)'
+    'name': 'meta.embedded.block.xml'
+    'patterns': [
+      {
+        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)XML)\\b\\1)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.ruby'
+        'contentName': 'text.xml'
+        'end': '\\s*\\2$\\n?'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.ruby'
+        'name': 'string.unquoted.heredoc.ruby'
+        'patterns': [
+          {
+            'include': '#heredoc'
+          }
+          {
+            'include': '#interpolated_ruby'
+          }
+          {
+            'include': 'text.xml'
+          }
+          {
+            'include': '#escaped_char'
+          }
+        ]
+      }
+    ]
+  }
+  {
     'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)SQL)\\b\\1))'
     'comment': 'Heredoc with embedded sql'
     'end': '(?!\\G)'


### PR DESCRIPTION
### Description of the Change

It enables highlighting embedded XML in HEREDOC block. I personally work with a lot of XML nowadays so I hope someone else than me can benefit of that as well 🙃

### Alternate Designs

No

### Benefits

It's possible to see XML syntax in HEREDOC block

### Possible Drawbacks

Unknown

### Applicable Issues

Unknown
