### PR TITLE
Fix heredoc literal highlight ends

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1418,7 +1418,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'text.html'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1452,7 +1452,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'text.xml'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1486,7 +1486,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.sql'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1520,7 +1520,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.graphql'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1554,7 +1554,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.css'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1588,7 +1588,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.cpp'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1629,7 +1629,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.c'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1663,7 +1663,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.js'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1697,7 +1697,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.js.jquery'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1731,7 +1731,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.shell'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1765,7 +1765,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.lua'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1799,7 +1799,7 @@
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
         'contentName': 'source.ruby'
-        'end': '\\s*\\2$\\n?'
+        'end': '^\\s*\\2$\\n?'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.ruby'
@@ -1849,7 +1849,7 @@
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
     'comment': 'heredoc with multiple inputs and indented terminator'
-    'end': '\\s*\\4$'
+    'end': '^\\s*\\4$'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -765,6 +765,11 @@ describe "Ruby grammar", ->
     expect(lines[0][0]).toEqual value: '<<~EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
     expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
 
+  it "tokenizes heredoc which includes identifier in end of a line", ->
+    lines = grammar.tokenizeLines('<<-EOS\nThis is text\nThis is Not EOS\nEOS')
+    expect(lines[0][0]).toEqual value: '<<-EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(lines[3][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
+
   it "tokenizes Kernel support functions autoload? and exit!", ->
     lines = grammar.tokenizeLines('p autoload?(:test)\nexit!\nat_exit!')
     expect(lines[0][2]).toEqual value: 'autoload?', scopes: ['source.ruby', 'support.function.kernel.ruby']


### PR DESCRIPTION
### Description of the Change

- Change detect of heredoc literal highlight ends
  - Not allow non-space character before identifiers

### Alternate Designs

Nothing.

### Benefits

- Fix heredoc highlights which have identifiers at the line.

#### for example

```rb
# In exists: highlighting on line 2-4. This fix: highlighting on line 2-5
<<-EOS
  This is a text.
  This line is not EOS
EOS
```

### Possible Drawbacks

Unknown.

### Applicable Issues

Nothing.