### PR TITLE
Remove include of "source.c++" from Heredoc

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1600,13 +1600,6 @@
           {
             'include': '#interpolated_ruby'
           }
-
-          # TODO: remove once new language-c package is released with the
-          # 'source.cpp' scope name
-          {
-            'include': 'source.c++'
-          }
-
           {
             'include': 'source.cpp'
           }


### PR DESCRIPTION
A TODO to remove the include was added in #77 when language-c was in the middle of a transition between the two different names, from "source.c++" to "source.cpp". (See [#55 at language-c](https://github.com/atom/language-c/pull/55))

I believe the thought was to remove it when the language-c package released a new version. Now, more than two years since it was added, there's no reason to keep it. language-c has released several versions since and everyone who has the latest language-ruby version will also have a language-c with "source.c++" changed to "source.cpp".