### PR TITLE
feat(ruby.cson) support quoted heredoc literals

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1407,13 +1407,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)HTML)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)HTML)\\b\\1))'
     'comment': 'Heredoc with embedded html'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.html'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)HTML)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)HTML)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1441,13 +1441,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)XML)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)XML)\\b\\1))'
     'comment': 'Heredoc with embedded xml'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.xml'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)XML)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)XML)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1475,13 +1475,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)SQL)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)SQL)\\b\\1))'
     'comment': 'Heredoc with embedded sql'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.sql'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)SQL)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)SQL)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1509,13 +1509,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))'
     'comment': 'Heredoc with embedded GraphQL'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.graphql'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1543,13 +1543,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)CSS)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)CSS)\\b\\1))'
     'comment': 'Heredoc with embedded css'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.css'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)CSS)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)CSS)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1577,13 +1577,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)CPP)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)CPP)\\b\\1))'
     'comment': 'Heredoc with embedded c++'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.cpp'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)CPP)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)CPP)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1611,13 +1611,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)C)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)C)\\b\\1))'
     'comment': 'Heredoc with embedded c'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.c'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)C)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)C)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1645,13 +1645,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1))'
     'comment': 'Heredoc with embedded javascript'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.js'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1679,13 +1679,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)JQUERY)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1))'
     'comment': 'Heredoc with embedded jQuery javascript'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.js.jquery'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)JQUERY)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1713,13 +1713,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1))'
     'comment': 'Heredoc with embedded shell'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.shell'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1747,13 +1747,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)LUA)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)LUA)\\b\\1))'
     'comment': 'Heredoc with embedded lua'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.lua'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)LUA)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)LUA)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1781,13 +1781,13 @@
     ]
   }
   {
-    'begin': '(?=(?><<[-~]("?)((?:[_\\w]+_|)RUBY)\\b\\1))'
+    'begin': '(?=(?><<[-~](["\'`]?)((?:[_\\w]+_|)RUBY)\\b\\1))'
     'comment': 'Heredoc with embedded ruby'
     'end': '(?!\\G)'
     'name': 'meta.embedded.block.ruby'
     'patterns': [
       {
-        'begin': '(?><<[-~]("?)((?:[_\\w]+_|)RUBY)\\b\\1)'
+        'begin': '(?><<[-~](["\'`]?)((?:[_\\w]+_|)RUBY)\\b\\1)'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.ruby'
@@ -1815,11 +1815,11 @@
     ]
   }
   {
-    'begin': '(?>=\\s*<<(\\w+))'
+    'begin': '(?>=\\s*<<(["\'`]?)(\\w+)\\1)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'end': '^\\1$'
+    'end': '^\\2$'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'
@@ -1837,12 +1837,12 @@
     ]
   }
   {
-    'begin': '(?>((<<[-~](\\w+),\\s?)*<<[-~](\\w+)))'
+    'begin': '(?>((<<[-~](["\'`]?)(\\w+)\\3,\\s?)*<<[-~](["\'`]?)(\\w+)\\5))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
     'comment': 'heredoc with multiple inputs and indented terminator'
-    'end': '^\\s*\\4$'
+    'end': '^\\s*\\6$'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -765,6 +765,16 @@ describe "Ruby grammar", ->
     expect(lines[0][0]).toEqual value: '<<~EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
     expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
 
+  it "tokenizes quoted heredoc", ->
+    # Double-quoted heredoc:
+    lines = grammar.tokenizeLines('<<~"EOS"\nThis is text\nEOS')
+    expect(lines[0][0]).toEqual value: '<<~"EOS"', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
+    # Single-quoted heredoc:
+    lines = grammar.tokenizeLines('<<~\'EOS\'\nThis is text\nEOS')
+    expect(lines[0][0]).toEqual value: '<<~\'EOS\'', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
+
   it "tokenizes heredoc which includes identifier in end of a line", ->
     lines = grammar.tokenizeLines('<<-EOS\nThis is text\nThis is Not EOS\nEOS')
     expect(lines[0][0]).toEqual value: '<<-EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -774,6 +774,10 @@ describe "Ruby grammar", ->
     lines = grammar.tokenizeLines('<<~\'EOS\'\nThis is text\nEOS')
     expect(lines[0][0]).toEqual value: '<<~\'EOS\'', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
     expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
+    # Backtick-quoted heredoc:
+    lines = grammar.tokenizeLines('<<~`EOS`\nThis is text\nEOS')
+    expect(lines[0][0]).toEqual value: '<<~`EOS`', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']
+    expect(lines[2][0]).toEqual value: 'EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.end.ruby']
 
   it "tokenizes heredoc which includes identifier in end of a line", ->
     lines = grammar.tokenizeLines('<<-EOS\nThis is text\nThis is Not EOS\nEOS')


### PR DESCRIPTION
Thanks for maintaining this project and considering my PR! 

### Description of the Change

Ruby supports [quoted heredocs](https://ruby-doc.org/core-2.2.0/doc/syntax/literals_rdoc.html#label-Here+Documents): 

```ruby 
  string1 = <<-STR
    Hello World
  STR

  string2 = <<-"STR"
    Hello World
  STR

  string3 = <<-'STR'
    Hello World
  STR

  shell_block = <<-`COMMAND`
    ls ~
    pwd
  COMMAND
```

But they aren't captured by the current grammar. This change adds quotes to the heredoc regexps so that they'll be properly tokenized. 

### Alternate Designs

No alternate deisgns were considered.

### Benefits

We use single-quoted heredocs to assert that interpolation is not possible. This is a security check: interpolation can lead to various injection bugs. 

Embedded code is not highlighted right now: 

![image](https://user-images.githubusercontent.com/2231765/29464364-a7a39ee6-8403-11e7-8814-55b38c11e9b3.png)

But after this change, it will be highlighted!

### Possible Drawbacks

Added complexity to the heredoc regexp.

### Applicable Issues

I didn't find any.


