### PR TITLE
🐛 Properly handle variables ending in "do" followed by pipes

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1860,7 +1860,7 @@
     ]
   }
   {
-    'begin': '(?<={|do|{\\s|do\\s)(\\|)'
+    'begin': '(?<={|{\\s|[^A-Za-z0-9_]do|^do|[^A-Za-z0-9_]do\\s|^do\\s)(\\|)'
     'captures':
       '1':
         'name': 'punctuation.separator.variable.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -755,6 +755,12 @@ describe "Ruby grammar", ->
     expect(tokens[26]).toEqual value: 'false', scopes: ['source.ruby', 'constant.language.boolean.ruby']
     expect(tokens[27]).toEqual value: '|', scopes: ['source.ruby', 'punctuation.separator.variable.ruby']
 
+  it "does not erroneously tokenize a variable ending in `do` followed by a pipe as a block", ->
+    {tokens} = grammar.tokenizeLine('sudo ||= true')
+    expect(tokens[0]).toEqual value: 'sudo ', scopes: ['source.ruby']
+    expect(tokens[1]).toEqual value: '||=', scopes: ['source.ruby', 'keyword.operator.assignment.augmented.ruby']
+    expect(tokens[3]).toEqual value: 'true', scopes: ['source.ruby', 'constant.language.boolean.ruby']
+
   it "tokenizes <<- heredoc", ->
     lines = grammar.tokenizeLines('<<-EOS\nThis is text\nEOS')
     expect(lines[0][0]).toEqual value: '<<-EOS', scopes: ['source.ruby', 'string.unquoted.heredoc.ruby', 'punctuation.definition.string.begin.ruby']


### PR DESCRIPTION
### Description of the Change

Variables ending in "do" followed by || or ||= were mistakenly treated as blocks by the grammar:

<img src="https://user-images.githubusercontent.com/1724000/30776983-d1755cc2-a07e-11e7-929a-4748685984ac.png" width="248" />

The grammar was naively treating `do |` as a block. This PR just adds a few extra checks to ensure that `do` is not immediately preceded by an identifier character.

Tada!

<img src="https://user-images.githubusercontent.com/1724000/30777019-bcda7e36-a07f-11e7-9546-89de22af4cef.png" width="250" />


### Alternate Designs

It would be nice if this could be done using a more sane regex, but that is impossible since a lookbehind is necessary. Imagine if it were this:

```
\b(do|{)\s*|
```

Wouldn't that be nice!

### Benefits

Variables ending in `do` will not be confused with blocks. This is especially great for Spanish variable names.

### Possible Drawbacks

Can't imagine any, this is just a syntax.

### Applicable Issues

Fixes #214.
