### PR TITLE
Adding support for single-quoted heredocs

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -439,8 +439,7 @@
     'name': 'string.quoted.single.ruby'
     'patterns': [
       {
-        'match': '\\\\\'|\\\\\\\\'
-        'name': 'constant.character.escape.ruby'
+        'include': '#single_quoted_escape_chars'
       }
     ]
   }
@@ -1837,6 +1836,26 @@
     ]
   }
   {
+    'begin': '(?>=\\s*<<\'(\\w+)\')'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.ruby'
+    'comment': 'heredoc with single-quoted input'
+    'end': '^\\1$'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.ruby'
+    'name': 'string.quoted.single.ruby'
+    'patterns': [
+      {
+        'include': '#heredoc'
+      }
+      {
+        'include': '#single_quoted_escape_chars'
+      }
+    ]
+  }
+  {
     'begin': '(?>((<<[-~](\\w+),\\s?)*<<[-~](\\w+)))'
     'beginCaptures':
       '0':
@@ -1972,6 +1991,9 @@
   }
 ]
 'repository':
+  'single_quoted_escape_chars':
+    'match': '\\\\\'|\\\\\\\\'
+    'name': 'constant.character.escape.ruby'
   'escaped_char':
     'match': '\\\\(?:[0-7]{1,3}|x[\\da-fA-F]{1,2}|.)'
     'name': 'constant.character.escape.ruby'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adding support for single-quoted heredocs.  This commit contains support for the "simple" case:

```ruby
a = <<'EOF'
This is \'quoted\' \\ properly.
EOF
```

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.  This is my first venture into CoffeeScript.

### Benefits

<!-- What benefits will be realized by the code change? -->

Single-quoted heredocs will be supported.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I can't come up with a way to do this for heredocs that have multiple inputs.  Also, if I were to implement this for all of the "embedded" patterns, it would really bloat `ruby.cson`.  I'm open to suggestions.

### Applicable Issues

<!-- Enter any applicable Issues here -->
