### PR TITLE
add interpolated snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -344,3 +344,8 @@
   'erb_exec_block_after_quote':
     'prefix': '\"-'
     'body': '\"<% $1 %>'
+
+'.string.quoted.double.ruby:not(.string .source), .string.quoted.double.ruby:not(.string .source)':
+  'Interpolated Code':
+    'prefix': '#'
+    'body': '#{$1}$2'


### PR DESCRIPTION
### Description of the Change

Add interpolated snippet to ruby strings'

![interpolated](https://user-images.githubusercontent.com/1993929/32119506-1d216538-bb1b-11e7-81cd-a063fdae240e.gif)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

More users will be able to guess this functionality, I was expecting ruby strings to have since Coffeescript alredy have this snippet.