### PR TITLE
Add tree-sitter Ruby grammar

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: "{build}"
 
+image: Visual Studio 2015
+
 platform: x64
 
 branches:

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -100,6 +100,10 @@ scopes:
   '"case"': 'keyword.control'
   '"when"': 'keyword.control'
 
+  'interpolation': 'source.ruby'
+  'interpolation > "#{"': 'punctuation.section.embedded'
+  'interpolation > "}"': 'punctuation.section.embedded'
+
   'constant': 'entity.name.type.class'
 
   'self': 'variable.other'

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -1,0 +1,123 @@
+id: 'ruby'
+name: 'Ruby'
+type: 'tree-sitter'
+parser: 'tree-sitter-ruby'
+
+fileTypes: [
+  'rb'
+]
+
+comments:
+  start: '# '
+
+folds: [
+  {
+    type: ['block', 'do_block']
+    start: {type: 'block_parameters'}
+    end: {index: -1}
+  }
+  {
+    type: 'begin'
+    start: {index: 0}
+    end: {type: 'rescue'}
+  }
+  {
+    type: 'heredoc_end'
+  }
+  {
+    type: [
+      'hash'
+      'array'
+      'begin'
+      'block'
+      'do_block'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    type: 'argument_list'
+    start: {index: 0, type: '('}
+    end: {index: -1}
+  }
+  {
+    type: 'class'
+    start: {type: 'superclass'}
+    end: {index: -1}
+  }
+  {
+    type: 'class'
+    start: {index: 1}
+    end: {index: -1}
+  }
+  {
+    type: ['method', 'singleton_method']
+    start: {type: 'method_parameters'}
+    end: {index: -1}
+  }
+  {
+    type: ['method', 'singleton_method']
+    start: {index: 1}
+    end: {index: -1}
+  }
+  {
+    type: ['if', 'unless', 'elsif']
+    start: {index: 1}
+    end: {type: 'else'}
+  }
+  {
+    type: ['if', 'unless', 'elsif']
+    start: {index: 1}
+    end: {type: 'elsif'}
+  }
+  {
+    type: ['if', 'unless']
+    start: {index: 1}
+    end: {index: -1}
+  }
+  {
+    type: 'else'
+    start: {index: 0}
+  }
+]
+
+scopes:
+  '"if"': 'keyword.control'
+  '"unless"': 'keyword.control'
+  '"def"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"end"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"elsif"': 'keyword.control'
+  '"class"': 'keyword.control'
+  '"module"': 'keyword.control'
+  '"begin"': 'keyword.control'
+  '"rescue"': 'keyword.control'
+  '"ensure"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"yield"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"when"': 'keyword.control'
+
+  'constant': 'entity.name.type.class'
+
+  'self': 'variable.other'
+
+  'method > identifier': 'entity.name.function'
+  'call > identifier:nth-child(2)': 'entity.name.function'
+  'method_call > identifier:nth-child(0)': 'entity.name.function'
+
+  'class_variable': 'variable.other.object.property'
+  'instance_variable': 'variable.other.object.property'
+  'symbol': 'constant.other'
+
+  'comment': 'comment'
+  'string': 'string'
+  'regex': 'string.regex'
+  'heredoc_beginning': 'string'
+  'heredoc_end': 'string'
+  'integer': 'constant.numeric'
+
+  'nil': 'constant.language.nil'
+  'true': 'constant.language.true'
+  'false': 'constant.language.false'

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -108,7 +108,11 @@ scopes:
 
   'self': 'variable.other'
 
+  'word_array': 'string'
+
   'method > identifier': 'entity.name.function'
+  'singleton_method > identifier:nth-child(3)': 'entity.name.function'
+  'setter > identifier': 'entity.name.function'
   'call > identifier:nth-child(2)': 'entity.name.function'
   'method_call > identifier:nth-child(0)': 'entity.name.function'
 
@@ -118,9 +122,9 @@ scopes:
 
   'comment': 'comment'
   'string': 'string'
-  'regex': 'string.regex'
+  'regex': 'string.regexp'
   'heredoc_beginning': 'string'
-  'heredoc_end': 'string'
+  'heredoc_body': 'string'
   'integer': 'constant.numeric'
 
   'nil': 'constant.language.nil'

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -65,12 +65,7 @@ folds: [
   {
     type: ['if', 'unless', 'elsif']
     start: {index: 1}
-    end: {type: 'else'}
-  }
-  {
-    type: ['if', 'unless', 'elsif']
-    start: {index: 1}
-    end: {type: 'elsif'}
+    end: {type: ['else', 'elsif']}
   }
   {
     type: ['if', 'unless']
@@ -80,6 +75,10 @@ folds: [
   {
     type: 'else'
     start: {index: 0}
+  }
+  {
+    type: 'elsif'
+    start: {index: 1}
   }
 ]
 

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -3,6 +3,8 @@ name: 'Ruby'
 type: 'tree-sitter'
 parser: 'tree-sitter-ruby'
 
+injectionRegExp: 'rb|ruby'
+
 fileTypes: [
   'rb'
 ]

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -108,7 +108,10 @@ scopes:
 
   'self': 'variable.other'
 
-  'word_array': 'string'
+  '"%w("': 'punctuation.definition.parameters'
+  '"%i("': 'punctuation.definition.parameters'
+  '"("': 'punctuation.definition.parameters'
+  '")"': 'punctuation.definition.parameters'
 
   'method > identifier': 'entity.name.function'
   'singleton_method > identifier:nth-child(3)': 'entity.name.function'
@@ -119,9 +122,11 @@ scopes:
   'class_variable': 'variable.other.object.property'
   'instance_variable': 'variable.other.object.property'
   'symbol': 'constant.other'
+  'bare_symbol': 'constant.other'
 
   'comment': 'comment'
   'string': 'string'
+  'bare_string': 'string'
   'regex': 'string.regexp'
   'heredoc_beginning': 'string'
   'heredoc_body': 'string'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.13.2"
+    "tree-sitter-ruby": "^0.13.3"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.13.0"
+    "tree-sitter-ruby": "^0.13.2"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
+  "dependencies": {
+    "tree-sitter-ruby": "^0.3.1"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.3.1"
+    "tree-sitter-ruby": "^0.13.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
This adds an alternative Ruby grammar that uses [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby) for parsing instead of [first-mate](https://github.com/atom/first-mate).