### PR TITLE
Add support for csvbuilder extensions

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -11,6 +11,7 @@
   'capfile'
   'cgi'
   'cr'
+  'csvbuilder'
   'Dangerfile'
   'Deliverfile'
   'Fastfile'


### PR DESCRIPTION
### Description of the Change

We use the `.csvbuilder` file type for generating CSVs, they're just Ruby code. This adds the extension to the language-ruby library for enabling syntax highlighting on those files by default. 

### Alternate Designs

N/A

### Benefits

`.csvbuilder` files will display with Ruby syntax highlighting by default.

### Possible Drawbacks

If someone uses the `.csvbuilder` extension for a file used in a different language; they'll have odd syntax highlighting. 

### Applicable Issues

N/A

### Tests

I didn't see any information about testing language packages; if I didn't look hard enough or am missing something - I'd be happy to write tests for this change (but don't really feel that it is warranted in this case). 