### PR TITLE
Support multiline YARD comments

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -1359,6 +1359,9 @@
     'name': 'comment.block.documentation.ruby'
   }
   {
+    'include': '#yard'
+  }
+  {
     'begin': '(^[ \\t]+)?(?=#)'
     'beginCaptures':
       '1':
@@ -1372,11 +1375,6 @@
             'name': 'punctuation.definition.comment.ruby'
         'end': '\\n'
         'name': 'comment.line.number-sign.ruby'
-        'patterns': [
-          {
-            'include': '#yard'
-          }
-        ]
       }
     ]
   }
@@ -2286,7 +2284,6 @@
       }
     ]
   'yard':
-    'name': 'comment.line.yard.ruby'
     'patterns': [
       {
         'include': '#yard_comment'
@@ -2306,77 +2303,147 @@
     ]
   'yard_comment':
     'comment': 'For YARD tags that follow the tag-comment pattern'
-    'match': '(@)(abstract|api|author|deprecated|example|note|overload|since|todo|version)(?=\\s)(.*)$'
-    'captures':
+    'begin': '^(\\s*)(#)(\\s*)(@)(abstract|api|author|deprecated|example|macro|note|overload|since|todo|version)(?=\\s|$)'
+    'beginCaptures':
       '1':
-        'name': 'comment.line.keyword.punctuation.yard.ruby'
+        'name': ''
       '2':
-        'name': 'comment.line.keyword.yard.ruby'
+        'name': 'punctuation.definition.comment.ruby'
       '3':
-        'name': 'comment.line.string.yard.ruby'
+        'name': ''
+      '4':
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
+      '5':
+        'name': 'comment.line.keyword.yard.ruby'
+    'end': '^(?!\\s*#\\3\\s{2,})'
+    'contentName': 'comment.line.string.yard.ruby'
+    'name': 'comment.line.number-sign.ruby'
+    'patterns': [
+      {
+        'include': '#yard'
+      }
+      {
+        'include': '#yard_continuation'
+      }
+    ]
   'yard_name_types':
     'comment': 'For YARD tags that follow the tag-name-types-comment pattern'
-    'match': '(@)(attr|attr_reader|attr_writer|option|param|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(])))?(.*)$'
+    'begin': '^(\\s*)(#)(\\s*)(@)(attr|attr_reader|attr_writer|option|param|see|yieldparam)(?=\\s)(\\s+([a-z_][a-zA-Z_]*))?(\\s+((\\[).+(])))?'
+    'beginCaptures':
+      '1':
+        'name': ''
+      '2':
+        'name': 'punctuation.definition.comment.ruby'
+      '3':
+        'name': ''
+      '4':
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
+      '5':
+        'name': 'comment.line.keyword.yard.ruby'
+      '6':
+        'name': 'comment.line.yard.ruby'
+      '7':
+        'name': 'comment.line.parameter.yard.ruby'
+      '8':
+        'name': 'comment.line.yard.ruby'
+      '9':
+        'name': 'comment.line.type.yard.ruby'
+      '10':
+        'name': 'comment.line.punctuation.yard.ruby'
+      '11':
+        'name': 'comment.line.punctuation.yard.ruby'
+    'end': '^(?!\\s*#\\3\\s{2,})'
+    'contentName': 'comment.line.string.yard.ruby'
+    'name': 'comment.line.number-sign.ruby'
+    'patterns': [
+      {
+        'include': '#yard'
+      }
+      {
+        'include': '#yard_continuation'
+      }
+    ]
+  'yard_tag':
+    'comment': 'For YARD tags that are just the tag'
+    'match': '^(\\s*)(#)(\\s*)(@)(private)$'
     'captures':
       '1':
-        'name': 'comment.line.keyword.punctuation.yard.ruby'
+        'name': ''
       '2':
-        'name': 'comment.line.keyword.yard.ruby'
+        'name': 'punctuation.definition.comment.ruby'
       '3':
-        'name': 'comment.line.yard.ruby'
+        'name': ''
       '4':
-        'name': 'comment.line.parameter.yard.ruby'
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
       '5':
-        'name': 'comment.line.yard.ruby'
+        'name': 'comment.line.keyword.yard.ruby'
+    'name': 'comment.line.number-sign.ruby'
+  'yard_types':
+    'comment': 'For YARD tags that follow the tag-types-comment pattern'
+    'begin': '^(\\s*)(#)(\\s*)(@)(raise|return|yield(?:return)?)(?=\\s)(\\s+((\\[).+(])))?'
+    'beginCaptures':
+      '1':
+        'name': ''
+      '2':
+        'name': 'punctuation.definition.comment.ruby'
+      '3':
+        'name': ''
+      '4':
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
+      '5':
+        'name': 'comment.line.keyword.yard.ruby'
       '6':
-        'name': 'comment.line.type.yard.ruby'
+        'name': 'comment.line.yard.ruby'
       '7':
-        'name': 'comment.line.punctuation.yard.ruby'
+        'name': 'comment.line.type.yard.ruby'
       '8':
         'name': 'comment.line.punctuation.yard.ruby'
       '9':
-        'name': 'comment.line.string.yard.ruby'
-  'yard_tag':
-    'comment': 'For YARD tags that are just the tag'
-    'match': '(@)(private)$'
-    'captures':
-      '1':
-        'name': 'comment.line.keyword.punctuation.yard.ruby'
-      '2':
-        'name': 'comment.line.keyword.yard.ruby'
-  'yard_types':
-    'comment': 'For YARD tags that follow the tag-types-comment pattern'
-    'match': '(@)(raise|return|yield(?:return)?)(?=\\s)(\\s+((\\[).+(])))?(.*)$'
-    'captures':
-      '1':
-        'name': 'comment.line.keyword.punctuation.yard.ruby'
-      '2':
-        'name': 'comment.line.keyword.yard.ruby'
-      '3':
-        'name': 'comment.line.yard.ruby'
-      '4':
-        'name': 'comment.line.type.yard.ruby'
-      '5':
         'name': 'comment.line.punctuation.yard.ruby'
-      '6':
-        'name': 'comment.line.punctuation.yard.ruby'
-      '7':
-        'name': 'comment.line.string.yard.ruby'
+    'end': '^(?!\\s*#\\3\\s{2,})'
+    'contentName': 'comment.line.string.yard.ruby'
+    'name': 'comment.line.number-sign.ruby'
+    'patterns': [
+      {
+        'include': '#yard'
+      }
+      {
+        'include': '#yard_continuation'
+      }
+    ]
   'yard_directive':
     'comment': 'For YARD directives'
-    'match': '(@!)(attribute|endgroup|group|macro|method|parse|scope|visibility)(\\s+((\\[).+(])))?(?=\\s)(.*)$'
-    'captures':
+    'begin': '^(\\s*)(#)(\\s*)(@!)(attribute|endgroup|group|macro|method|parse|scope|visibility)(\\s+((\\[).+(])))?(?=\\s)'
+    'beginCaptures':
       '1':
-        'name': 'comment.line.keyword.punctuation.yard.ruby'
+        'name': ''
       '2':
-        'name': 'comment.line.keyword.yard.ruby'
+        'name': 'punctuation.definition.comment.ruby'
       '3':
-        'name': 'comment.line.yard.ruby'
+        'name': ''
       '4':
-        'name': 'comment.line.type.yard.ruby'
+        'name': 'comment.line.keyword.punctuation.yard.ruby'
       '5':
-        'name': 'comment.line.punctuation.yard.ruby'
+        'name': 'comment.line.keyword.yard.ruby'
       '6':
-        'name': 'comment.line.punctuation.yard.ruby'
+        'name': 'comment.line.yard.ruby'
       '7':
-        'name': 'comment.line.string.yard.ruby'
+        'name': 'comment.line.type.yard.ruby'
+      '8':
+        'name': 'comment.line.punctuation.yard.ruby'
+      '9':
+        'name': 'comment.line.punctuation.yard.ruby'
+    'end': '^(?!\\s*#\\3\\s{2,})'
+    'contentName': 'comment.line.string.yard.ruby'
+    'name': 'comment.line.number-sign.ruby'
+    'patterns': [
+      {
+        'include': '#yard'
+      }
+      {
+        'include': '#yard_continuation'
+      }
+    ]
+  'yard_continuation':
+    'match': '^\\s*#'
+    'name': 'punctuation.definition.comment.ruby'

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -585,36 +585,51 @@ describe "Ruby grammar", ->
     expect(tokens[2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
     expect(tokens[3]).toEqual value: 'private', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
 
-    {tokens} = grammar.tokenizeLine('# @deprecated Because I said so')
-    expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
-    expect(tokens[2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
-    expect(tokens[3]).toEqual value: 'deprecated', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
-    expect(tokens[4]).toEqual value: ' Because I said so', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    tokens = grammar.tokenizeLines '''
+      # @deprecated Because I said so,
+      #   end of discussion
+    '''
+    expect(tokens[0][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
+    expect(tokens[0][2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
+    expect(tokens[0][3]).toEqual value: 'deprecated', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
+    expect(tokens[0][4]).toEqual value: ' Because I said so,', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    expect(tokens[1][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[1][1]).toEqual value: '   end of discussion', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
-    {tokens} = grammar.tokenizeLine('# @raise [Bar] Baz')
-    expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
-    expect(tokens[2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
-    expect(tokens[3]).toEqual value: 'raise', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
-    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
-    expect(tokens[5]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[6]).toEqual value: 'Bar', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
-    expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[8]).toEqual value: ' Baz', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    tokens = grammar.tokenizeLines '''
+      # @raise [AccountBalanceError] if the account does not have
+      #   sufficient funds to perform the transaction
+    '''
+    expect(tokens[0][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
+    expect(tokens[0][2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
+    expect(tokens[0][3]).toEqual value: 'raise', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
+    expect(tokens[0][4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
+    expect(tokens[0][5]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][6]).toEqual value: 'AccountBalanceError', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
+    expect(tokens[0][7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][8]).toEqual value: ' if the account does not have', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    expect(tokens[1][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[1][1]).toEqual value: '   sufficient funds to perform the transaction', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
-    {tokens} = grammar.tokenizeLine('# @param foo [Bar] Baz')
-    expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
-    expect(tokens[2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
-    expect(tokens[3]).toEqual value: 'param', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
-    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
-    expect(tokens[5]).toEqual value: 'foo', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.parameter.yard.ruby']
-    expect(tokens[6]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
-    expect(tokens[7]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[8]).toEqual value: 'Bar', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
-    expect(tokens[9]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[10]).toEqual value: ' Baz', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    tokens = grammar.tokenizeLines '''
+      # @param value [Object] describe value param in a long way which
+      #   makes it multiline
+    '''
+    expect(tokens[0][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
+    expect(tokens[0][2]).toEqual value: '@', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
+    expect(tokens[0][3]).toEqual value: 'param', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
+    expect(tokens[0][4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
+    expect(tokens[0][5]).toEqual value: 'value', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.parameter.yard.ruby']
+    expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
+    expect(tokens[0][7]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][8]).toEqual value: 'Object', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
+    expect(tokens[0][9]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][10]).toEqual value: ' describe value param in a long way which', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    expect(tokens[1][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[1][1]).toEqual value: '   makes it multiline', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
     {tokens} = grammar.tokenizeLine('# @param [Bar] Baz')
     expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
@@ -649,16 +664,21 @@ describe "Ruby grammar", ->
     expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
     expect(tokens[8]).toEqual value: ' comment', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
-    {tokens} = grammar.tokenizeLine('# @!attribute [r] foo comment')
-    expect(tokens[0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
-    expect(tokens[2]).toEqual value: '@!', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
-    expect(tokens[3]).toEqual value: 'attribute', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
-    expect(tokens[4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
-    expect(tokens[5]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[6]).toEqual value: 'r', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
-    expect(tokens[7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
-    expect(tokens[8]).toEqual value: ' foo comment', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    tokens = grammar.tokenizeLines '''
+      # @!attribute [r] count the number of items
+      #   present in the list
+    '''
+    expect(tokens[0][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby']
+    expect(tokens[0][2]).toEqual value: '@!', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.punctuation.yard.ruby']
+    expect(tokens[0][3]).toEqual value: 'attribute', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.keyword.yard.ruby']
+    expect(tokens[0][4]).toEqual value: ' ', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby']
+    expect(tokens[0][5]).toEqual value: '[', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][6]).toEqual value: 'r', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby']
+    expect(tokens[0][7]).toEqual value: ']', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.yard.ruby', 'comment.line.type.yard.ruby', 'comment.line.punctuation.yard.ruby']
+    expect(tokens[0][8]).toEqual value: ' count the number of items', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
+    expect(tokens[1][0]).toEqual value: '#', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby', 'punctuation.definition.comment.ruby']
+    expect(tokens[1][1]).toEqual value: '   present in the list', scopes: ['source.ruby', 'comment.line.number-sign.ruby', 'comment.line.string.yard.ruby']
 
   it "tokenizes a method with *args properly", ->
     {tokens} = grammar.tokenizeLine('def method(*args)')


### PR DESCRIPTION
### Description of the Change

YARD allows comments to extend over multiple lines provided that the subsequent lines are indented (within the comment) at least two spaces from the tag. This change extends the YARD-specific comment highlighting onto those subsequent lines.

### Alternate Designs

None

### Benefits

Before, confusing and hard to read:
<img width="610" alt="screen shot 2018-06-01 at 15 45 10" src="https://user-images.githubusercontent.com/4642599/40860301-e9f32a46-65b2-11e8-80a0-5104dfd758c1.png">

After, easy to read and nice looking:
<img width="609" alt="screen shot 2018-06-01 at 15 45 36" src="https://user-images.githubusercontent.com/4642599/40860330-fcb031d8-65b2-11e8-8c35-666b4d8f7fef.png">

### Possible Drawbacks

None that I can think of

### Applicable Issues

Closes #228