### PR TITLE
Add ERB highlighting inside of script tags

### DIFF
--- a/grammars/html (ruby - erb).cson
+++ b/grammars/html (ruby - erb).cson
@@ -5,7 +5,7 @@
   'html.erb'
 ]
 'injections':
-  'text.html.erb - (meta.embedded.block.erb | meta.embedded.line.erb | meta.tag | comment), meta.tag string.quoted':
+  'text.html.erb - (meta.embedded.block.erb | meta.embedded.line.erb | meta.tag | comment), meta.tag string.quoted, L:source.js.embedded.html':
     'patterns': [
       {
         'begin': '(^\\s*)(?=<%+#(?![^%]*%>))'


### PR DESCRIPTION
### Description of the Change
This adds embedded js rules to the grammar for `html.erb` files so that erb syntax highlighting will work inside of script tags.

### Alternate Designs

None

### Benefits
ERB highlighting will work correctly when placed inside of a script tag.

Before:
![before](https://user-images.githubusercontent.com/12213081/47019426-086a9d00-d125-11e8-9da3-ea294c71e8d9.png)

After
![after](https://user-images.githubusercontent.com/12213081/47019431-0bfe2400-d125-11e8-9e75-03aa2f46b272.png)

### Possible Drawbacks

None that I am aware of

### Applicable Issues
#192 and #230
