### PR TITLE
Add more scopes to the tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -120,6 +120,7 @@ scopes:
     {match: '^[A-Z_]+$', scopes: 'constant'}
     'entity.name.type.class'
   ]
+  'superclass > constant': 'entity.other.inherited-class'
 
   'identifier': [
     {
@@ -146,9 +147,11 @@ scopes:
     'entity.name.function'
   ]
 
+  'block_parameters > identifier': 'variable.other.block'
+  'method_parameters > identifier': 'variable.parameter.function'
   'class_variable': 'variable.other.object.property'
   'instance_variable': 'variable.other.object.property'
-  'symbol': 'constant.other'
+  'symbol': 'constant.other.symbol'
   'bare_symbol': 'constant.other'
 
   'comment': 'comment'

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -149,6 +149,7 @@ scopes:
 
   'block_parameters > identifier': 'variable.other.block'
   'method_parameters > identifier': 'variable.parameter.function'
+  'keyword_parameter > identifier:nth-child(0)': 'constant.other.symbol'
   'class_variable': 'variable.other.object.property'
   'instance_variable': 'variable.other.object.property'
   'symbol': 'constant.other.symbol'

--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -117,7 +117,7 @@ scopes:
   'interpolation > "}"': 'punctuation.section.embedded'
 
   'constant': [
-    {match: '^[A-Z_]+$', scopes: 'constant'}
+    {match: '^[A-Z_]+$', scopes: 'variable.constant'}
     'entity.name.type.class'
   ]
   'superclass > constant': 'entity.other.inherited-class'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There were a couple of missing scope mappings that made the tree-sitter grammar not match the textmate grammar.

* Scope block and method parameters to match the textmate grammar
* Change the class of symbol to match the textmate grammar
* Scope inherited classes differently from classes to match the textmate grammar

### Alternate Designs

N/A

### Benefits

Matches the textmate grammar more closely

### Verification process

I used the following ruby file to test these new scope mappings

```ruby
class OrderItem < ApplicationRecord

end

imablock do |param1, param2|
  OrderItem
end

def imablock(param1, param2)
end

def predicate?(date: start_on)
  do_a_thing
end

{key: CONSTANT, key2: 123, key3: false, key4: :symbol}
```

![image](https://user-images.githubusercontent.com/1058982/47487971-c8519b80-d843-11e8-960d-0a7352422798.png)


### Applicable Issues

Fixes https://github.com/tree-sitter/tree-sitter-ruby/issues/94
Fixes https://github.com/atom/language-ruby/issues/243
Fixes https://github.com/atom/language-ruby/issues/242
Fixes https://github.com/atom/language-ruby/issues/241