### PR TITLE
Add ERB if block snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -344,3 +344,9 @@
   'erb_exec_block_after_quote':
     'prefix': '\"-'
     'body': '\"<% $1 %>'
+  'erb_if_block':
+    'prefix': '-if'
+    'body': '<% if ${1:condition} %>\n\t$0\n<% end %>'
+  # Turn off iframe since it conflicts with the if block
+  'Inline Frame':
+    'prefix': 'iframe'


### PR DESCRIPTION
### Description of the Change

Adds an if block snippet for ERB files. Type `-if` and press enter.

```erb
<% if condition %>
  
<% end %>
```

### Benefits

Allows adding if blocks to ERB files more quickly.

### Possible Drawbacks

The if block snippet conflicts with the `iframe` snippet from HTML so this change turns it off in ERB files since it is my believe that if blocks are more common than iframe elements. 
