### PR TITLE
Scope self as variable.language

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -133,7 +133,7 @@ scopes:
 
   'escape_sequence': 'constant.character.escape'
 
-  'self': 'variable.other'
+  'self': 'variable.language'
 
   '"%w("': 'punctuation.definition.parameters'
   '"%i("': 'punctuation.definition.parameters'


### PR DESCRIPTION
Textmate already has this scoped as `variable.language.self.ruby` and not `variable.other`.

This is required for https://github.com/atom/atom/pull/18383#issuecomment-435460854 in one-dark/light-syntax

/cc: @maxbrunsfeld 