### PR TITLE
Fix Tree Sitter syntax highlighting issues for floats and some integer types

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -165,6 +165,7 @@ scopes:
 
   'comment': 'comment'
   'regex': 'string.regexp'
+  'float': 'constant.numeric'
   'integer': 'constant.numeric'
   'string, bare_string, subshell, heredoc_beginning, heredoc_body': 'string'
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.13.10"
+    "tree-sitter-ruby": "^0.13.12"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
### Description of the Change

This change fixes syntax highlighting issues with floats and some integer types when using the Tree Sitter Ruby grammar.  The highlighting issues are demonstrated in this screenshot from issue #251:

![](https://user-images.githubusercontent.com/44983951/48377719-84142700-e69c-11e8-928d-21df4c157cf2.png)

Here's a screenshot from the fixes to `tree-sitter-ruby` and `language-ruby`:

![image](https://user-images.githubusercontent.com/79405/51278923-c6a1fa80-1990-11e9-9644-e03debdc722a.png)

### Alternate Designs

There is no alternate design, just fixing parsing regexes and scope mappings.

### Benefits

Correct highlighting of floats and integers with upcased binary and decimal prefixes.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #251.
https://github.com/tree-sitter/tree-sitter-ruby/pull/101
