### PR TITLE
Add `next` keyword to Tree Sitter's keyword.control scope

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -115,6 +115,7 @@ scopes:
   '"then"': 'keyword.control'
   '"for"': 'keyword.control'
   '"break"': 'keyword.control'
+  '"next"': 'keyword.control'
   '"retry"': 'keyword.control'
   '"while"': 'keyword.control'
   '"in"': 'keyword.control'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This adds the ruby `next` keyword to the list of keywords in the `keyword.control` scope.  I actually noticed several missing keywords compared to the old grammar

https://github.com/atom/language-ruby/blob/8cec2f9c34ec01f518306337cea1c167e150e3c4/grammars/ruby.cson#L154-L157

But I only really wanted the `next` keyword at the moment, and didn't want to hurt this PR's chances of getting merged by including other keywords.  You can see that the new grammar is missing `redo`, `super`, `undef`, `block_given?`, `defined?`, among others.  I did just notice that this excerpt is from a different scope, but I would still consider some of these to be control keywords.

*Edit by @rsese to add a screenshot and copy/paste code*

```ruby
(1..10).each do |i|
  if i % 2 == 0
   puts "even"
   next
  end
  puts i
end
```

Missing scope:

![tree-sitter](https://github-slack.s3.amazonaws.com/monosnap/test.rb__worktest-tree-sitter_2019-02-13_13-44-22.png)

### Alternate Designs

I did not consider any alternate designs.

### Benefits

🌈

### Possible Drawbacks

None?

### Applicable Issues

None.
