### PR TITLE
Allow numerals in all-caps constants

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -126,7 +126,7 @@ scopes:
   'interpolation > "}"': 'punctuation.section.embedded'
 
   'constant': [
-    {match: '^[A-Z_]+$', scopes: 'variable.constant'}
+    {match: '^[A-Z_0-9]+$', scopes: 'variable.constant'}
     'entity.name.type.class'
   ]
   'superclass > constant': 'entity.other.inherited-class'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.15.0"
+    "tree-sitter-ruby": "^0.15.2"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
Fixes #265

Previously, we only mapped upper-cased constant syntax nodes to the `variable.constant` scope if they contained upper-case letters or `_`, and otherwise mapped these constant references to `entity.name.type.class`. However, upper-case constants can also contain numbers. This PR adds `0-9` to the character class so that upper-case constants containing numbers are mapped to the `variable.constant` scope as well.