### PR TITLE
Add scopes for a number of items.

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -129,6 +129,7 @@ scopes:
     {match: '^[A-Z_0-9]+$', scopes: 'variable.constant'}
     'entity.name.type.class'
   ]
+  'global_variable': 'variable.other.readwrite.global'
   'superclass > constant': 'entity.other.inherited-class'
 
   'identifier': [
@@ -157,7 +158,7 @@ scopes:
   ]
 
   'block_parameters > identifier': 'variable.other.block'
-  'method_parameters > identifier': 'variable.parameter.function'
+  'method_parameters > identifier, optional_parameter > identifier': 'variable.parameter.function'
   'keyword_parameter > identifier:nth-child(0)': 'constant.other.symbol'
   'class_variable': 'variable.other.object.property'
   'instance_variable': 'variable.other.object.property'
@@ -168,7 +169,71 @@ scopes:
   'regex': 'string.regexp'
   'float': 'constant.numeric'
   'integer': 'constant.numeric'
-  'string, bare_string, subshell, heredoc_beginning, heredoc_body': 'string'
+
+  'string': [
+    {match: '^"', scopes: 'string.quoted.double.interpolated'}
+    {match: "^'", scopes: 'string.quoted.single'}
+    'string'
+  ]
+
+  # Quote delimiters are the only two children of these kinds of strings. If
+  # this changes in the tree-sitter parser in the future, these selectors will
+  # need updating.
+  "string > '\"':nth-child(0)": 'punctuation.definition.string.begin'
+  "string > '\"':nth-child(1)": 'punctuation.definition.string.end'
+  'string > "\'":nth-child(0)': 'punctuation.definition.string.begin'
+  'string > "\'":nth-child(1)': 'punctuation.definition.string.end'
+
+  'heredoc_beginning, heredoc_body': 'string.unquoted.heredoc.interpolated'
+  'subshell': 'string.quoted.subshell.interpolated'
+  'bare_string': 'string.unquoted.other'
+
+  '"="': 'keyword.operator.assignment'
+
+  '"+="': 'keyword.operator.assignment.augmented'
+  '"-="': 'keyword.operator.assignment.augmented'
+  '"*="': 'keyword.operator.assignment.augmented'
+  '"/="': 'keyword.operator.assignment.augmented'
+  '"<<="': 'keyword.operator.assignment.augmented'
+  '"%="': 'keyword.operator.assignment.augmented'
+  '"&="': 'keyword.operator.assignment.augmented'
+  '"&&="': 'keyword.operator.assignment.augmented'
+  '"|="': 'keyword.operator.assignment.augmented'
+  '"||="': 'keyword.operator.assignment.augmented'
+  '"**="': 'keyword.operator.assignment.augmented'
+  '"^="': 'keyword.operator.assignment.augmented'
+
+  '"<=>"': 'keyword.operator.comparison'
+  '"<"': 'keyword.operator.comparison'
+  '">"': 'keyword.operator.comparison'
+  '"<="': 'keyword.operator.comparison'
+  '">="': 'keyword.operator.comparison'
+  '"==="': 'keyword.operator.comparison'
+  '"=="': 'keyword.operator.comparison'
+  '"=~"': 'keyword.operator.comparison'
+  '"!="': 'keyword.operator.comparison'
+  '"!~"': 'keyword.operator.comparison'
+
+  '"&&"': 'keyword.operator.logical'
+  '"!"': 'keyword.operator.logical'
+  '"||"': 'keyword.operator.logical'
+  '"and"': 'keyword.operator.logical'
+  '"not"': 'keyword.operator.logical'
+  '"or"': 'keyword.operator.logical'
+  '"^"': 'keyword.operator.logical'
+
+  '"+"': 'keyword.operator.arithmetic'
+  '"-"': 'keyword.operator.arithmetic'
+  '"*"': 'keyword.operator.arithmetic'
+  '"/"': 'keyword.operator.arithmetic'
+  '"**"': 'keyword.operator.arithmetic'
+  '"&"': 'keyword.operator.arithmetic'
+  '"%"': 'keyword.operator.arithmetic'
+
+  'call > ".", call > "&."': 'punctuation.separator.method'
+
+  '";"': 'punctuation.separator.statement'
+  '","': 'punctuation.separator.object'
 
   'nil': 'constant.language.nil'
   'true': 'constant.language.true'


### PR DESCRIPTION

### Description of the Change

There are a number of scopes missing from the tree-sitter grammar that are present in its TM-style sibling. Many of these aren't used by `one-dark-syntax` or other common syntax themes, which is probably why they've been overlooked. Here's what I've added:

1. All strings, regardless of type, were scoped simply as `string`. I fleshed out these scope names to match the TM-style grammar: `string.quoted.single`, `string.quoted.double.interpolated`, et cetera.
2. Global variables had no scope name. Now they're scoped as `variable.other.readwrite.global`.
3. Operators weren't scoped at all. Now they're all given `keyword.operator` scope names equivalent to what they get in the TM-style grammar.
4. Ordinary method parameters were scoped as `variable.parameter`, but method parameters with default values got no scope. Fixed this oversight.
5. A number of `punctuation` scopes were added, including single- and double-quotes around strings, as well as the `.` and `&.` operators.

The `atom-light-syntax` theme is the first builtin theme I found that actually shows these differences. The existing grammar is on the left, and the updated grammar is on the right:

![language-ruby-1](https://user-images.githubusercontent.com/3450/61989065-81b9e900-afef-11e9-85bb-c7d65f4bc267.png)
![language-ruby-2](https://user-images.githubusercontent.com/3450/61989067-8383ac80-afef-11e9-8af3-0f9199e6c5a3.png)

### Alternate Designs

One thing worth mentioning: the distinguishing quotation marks via `:nth-child` selectors seems brittle. I'd love it if an `:nth-last-child` selector were available, but I've seen the code that implements `:nth-child` and I'm not sure I understand it well enough to try yet.

### Benefits

Better syntax highlighting and richer contextual information for commands.

### Possible Drawbacks

Hard to think of any. If this were a bold new direction for scope naming, perhaps there'd be some, but this is just about parity with the old grammar. The changes aren't even visible in most of the common syntax themes; the ones that are visible are obviously improved in consistency.

### Applicable Issues

Can't find any among the open issues.