### PR TITLE
Tokenize visibility modifier in Tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -137,6 +137,10 @@ scopes:
       match: '^__(FILE|LINE|ENCODING)__$',
       scopes: 'support.variable'
     }
+    {
+      match: '^(public|protected|private)$'
+      scopes: 'keyword.other.special-method'
+    }
   ]
 
   'escape_sequence': 'constant.character.escape'
@@ -154,6 +158,7 @@ scopes:
   'call > identifier:nth-child(2)': 'entity.name.function'
   'method_call > identifier:nth-child(0)': [
     {exact: 'require', scopes: 'support.function'}
+    {match: '^(public|protected|private)$', scopes: 'keyword.other.special-method'}
     'entity.name.function'
   ]
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tree-sitter-ruby": "^0.15.2"
   },
   "devDependencies": {
-    "coffeelint": "^1.10.1"
+    "coffeelint": "^1.10.1",
+    "dedent": "^0.7.0"
   }
 }

--- a/spec/erb-spec.coffee
+++ b/spec/erb-spec.coffee
@@ -1,4 +1,4 @@
-describe "HTML (Ruby - ERB) grammar", ->
+describe "TextMate HTML (Ruby - ERB) grammar", ->
   grammar = null
 
   beforeEach ->

--- a/spec/gemfile-spec.coffee
+++ b/spec/gemfile-spec.coffee
@@ -1,4 +1,4 @@
-describe "Gemfile grammar", ->
+describe "TextMate Gemfile grammar", ->
   grammar = null
 
   beforeEach ->

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -1,4 +1,4 @@
-describe "Ruby grammar", ->
+describe "TextMate Ruby grammar", ->
   grammar = null
 
   beforeEach ->

--- a/spec/tree-sitter-spec.js
+++ b/spec/tree-sitter-spec.js
@@ -1,0 +1,41 @@
+const dedent = require('dedent')
+
+describe('Tree-sitter Ruby grammar', () => {
+  beforeEach(async () => {
+    atom.config.set('core.useTreeSitterParsers', true)
+    await atom.packages.activatePackage('language-ruby')
+  })
+
+  it('tokenizes visibility modifiers', async () => {
+    const editor = await atom.workspace.open('foo.rb')
+
+    editor.setText(dedent`
+      public
+      protected
+      private
+
+      public def foo; end
+      protected def bar; end
+      private def baz; end
+    `)
+
+    expect(editor.scopeDescriptorForBufferPosition([0, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+    expect(editor.scopeDescriptorForBufferPosition([1, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+    expect(editor.scopeDescriptorForBufferPosition([2, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+    expect(editor.scopeDescriptorForBufferPosition([4, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+    expect(editor.scopeDescriptorForBufferPosition([5, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+    expect(editor.scopeDescriptorForBufferPosition([6, 0]).toString()).toBe(
+      '.source.ruby .keyword.other.special-method'
+    )
+  })
+})


### PR DESCRIPTION
Fixes #268

## Before and After

### Standalone visibility modifiers 

#### Before
<img width="718" alt="Screen Shot 2019-08-05 at 11 17 50 AM" src="https://user-images.githubusercontent.com/2988/62475468-14d2eb80-b773-11e9-8834-11e8fe6f3ca7.png">

#### After
<img width="718" alt="Screen Shot 2019-08-05 at 11 17 11 AM" src="https://user-images.githubusercontent.com/2988/62475467-14d2eb80-b773-11e9-88ec-fce9cc13c70f.png">

### Per-method visibility modifiers 

#### Before
<img width="718" alt="Screen Shot 2019-08-05 at 11 18 13 AM" src="https://user-images.githubusercontent.com/2988/62475470-14d2eb80-b773-11e9-8f50-defe6b0ff912.png">

#### After
<img width="718" alt="Screen Shot 2019-08-05 at 11 18 00 AM" src="https://user-images.githubusercontent.com/2988/62475469-14d2eb80-b773-11e9-8477-72e4707f1ad7.png">

---

🍐 'd with @as-cii 