### PR TITLE
Apply proper scopes for symbols when using Tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -168,7 +168,7 @@ scopes:
   'class_variable': 'variable.other.object.property'
   'instance_variable': 'variable.other.object.property'
   'symbol': 'constant.other.symbol'
-  'bare_symbol': 'constant.other'
+  'bare_symbol': 'constant.other.symbol'
 
   'comment': 'comment'
   'regex': 'string.regexp'

--- a/spec/tree-sitter-spec.js
+++ b/spec/tree-sitter-spec.js
@@ -6,6 +6,23 @@ describe('Tree-sitter Ruby grammar', () => {
     await atom.packages.activatePackage('language-ruby')
   })
 
+  it('tokenizes symbols', async () => {
+    const editor = await atom.workspace.open('foo.rb')
+
+    editor.setText(dedent`
+      :foo
+      %i(foo)
+    `)
+
+    expect(editor.scopeDescriptorForBufferPosition([0, 1]).toString()).toBe(
+      '.source.ruby .constant.other.symbol'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([1, 3]).toString()).toBe(
+      '.source.ruby .constant.other.symbol'
+    )
+  })
+
   it('tokenizes visibility modifiers', async () => {
     const editor = await atom.workspace.open('foo.rb')
 


### PR DESCRIPTION
Fixes #270

### Before (top) and After (bottom)

<img width="464" alt="Screen Shot 2019-08-14 at 1 09 43 PM" src="https://user-images.githubusercontent.com/2988/63041189-3b8cd280-be95-11e9-8338-50f26779d4ea.png">

### Demo

Following the changes in this pull request, Atom assigns the same scope in all three cases:

![demo](https://user-images.githubusercontent.com/2988/63041254-6c6d0780-be95-11e9-9ec2-77ef9bdeecde.gif)
