### PR TITLE
[tree-sitter] add variable identifier support in assignments expressions

### DIFF
--- a/grammars/tree-sitter-ruby.cson
+++ b/grammars/tree-sitter-ruby.cson
@@ -161,6 +161,8 @@ scopes:
   '")"': 'punctuation.definition.parameters'
 
   'method > identifier': 'entity.name.function'
+  'assignment > identifier': 'variable'
+
   'singleton_method > identifier:nth-child(3)': 'entity.name.function'
   'setter > identifier': 'entity.name.function'
   'call > identifier:nth-child(2)': 'entity.name.function'

--- a/spec/tree-sitter-spec.js
+++ b/spec/tree-sitter-spec.js
@@ -108,4 +108,26 @@ describe('Tree-sitter Ruby grammar', () => {
       '.source.ruby .keyword.control'
     )
   })
+
+  it('tokenizes variable in assignment expressions', async () => {
+    const editor = await atom.workspace.open('foo.rb')
+    editor.setText(dedent`
+      a = 10
+    `)
+
+    expect(editor.scopeDescriptorForBufferPosition([0, 0]).toString()).toBe(
+      '.source.ruby .variable'
+    )
+  })
+
+  it('does not tokenizes method call in assignment expressions', async () => {
+    const editor = await atom.workspace.open('foo.rb')
+    editor.setText(dedent`
+      foo() = 10
+    `)
+
+    expect(editor.scopeDescriptorForBufferPosition([0, 0]).toString()).not.toBe(
+      '.source.ruby .variable'
+    )
+  })
 })


### PR DESCRIPTION
# Description of the Change

![image](https://user-images.githubusercontent.com/16031425/65543813-87c33c00-df44-11e9-9175-eea029623c07.png)

Originally, variables created from assignments aren't given the `.syntax--variable` class, which makes the original language-ruby package not able to provide any type of way to style a variable.

### Alternate Designs

Some grammar package would also add `.syntax--other` for this kind of variable, can add if needed.

### Applicable Issues

#252 Adding more support for the new used tree-sitter parsing system
