### PR TITLE
Bump tree-sitter-ruby to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/language-ruby",
   "dependencies": {
-    "tree-sitter-ruby": "^0.15.3"
+    "tree-sitter-ruby": "^0.17.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1",


### PR DESCRIPTION
### Description of the Change

Bump tree-sitter-ruby to 0.17

### Alternate Designs

I do not think there is any viable alternative.

### Benefits

This should fix #274 by including fixes from https://github.com/tree-sitter/tree-sitter-ruby/issues/112

### Possible Drawbacks

Shouldn't be any.

### Applicable Issues

- #274
