### PR TITLE
Fix some typos

### DIFF
--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -371,7 +371,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.symbol.begin.ruby'
-    'comment': "symbol literal with '' delimitor"
+    'comment': "symbol literal with '' delimiter"
     'end': '\''
     'endCaptures':
       '0':
@@ -389,7 +389,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.section.symbol.begin.ruby'
-    'comment': 'symbol literal with "" delimitor'
+    'comment': 'symbol literal with "" delimiter'
     'end': '"'
     'endCaptures':
       '0':
@@ -414,7 +414,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': "string literal with '' delimitor"
+    'comment': "string literal with '' delimiter"
     'end': '\''
     'endCaptures':
       '0':
@@ -432,7 +432,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.ruby'
-    'comment': 'string literal with interpolation and "" delimitor'
+    'comment': 'string literal with interpolation and "" delimiter'
     'end': '"'
     'endCaptures':
       '0':

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -786,7 +786,7 @@
     'name': 'constant.other.symbol.ruby'
     'patterns': [
       {
-        'comment': 'Cant be named because its not neccesarily an escape.'
+        'comment': 'Cant be named because its not necessarily an escape.'
         'match': '\\\\.'
       }
     ]
@@ -990,7 +990,7 @@
     'name': 'string.quoted.other.ruby'
     'patterns': [
       {
-        'comment': 'Cant be named because its not neccesarily an escape.'
+        'comment': 'Cant be named because its not necessarily an escape.'
         'match': '\\\\.'
       }
     ]
@@ -1213,7 +1213,7 @@
     'name': 'string.quoted.other.ruby'
     'patterns': [
       {
-        'comment': 'Cant be named because its not neccesarily an escape.'
+        'comment': 'Cant be named because its not necessarily an escape.'
         'match': '\\\\.'
       }
     ]
@@ -1310,7 +1310,7 @@
     'name': 'constant.other.symbol.ruby'
     'patterns': [
       {
-        'comment': 'Cant be named because its not neccesarily an escape.'
+        'comment': 'Cant be named because its not necessarily an escape.'
         'match': '\\\\.'
       }
     ]

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -405,7 +405,7 @@
     ]
   }
   {
-    'comment': 'Needs higher precidence than regular expressions.'
+    'comment': 'Needs higher precedence than regular expressions.'
     'match': '(?<!\\()/='
     'name': 'keyword.operator.assignment.augmented.ruby'
   }


### PR DESCRIPTION
### Description of the Change

I found these typos in following repository 😅 

* https://github.com/rubyide/vscode-ruby/pull/709
* https://github.com/microsoft/vscode/pull/118923
* https://github.com/textmate/ruby.tmbundle/pull/138